### PR TITLE
[Pack ei-lineage] meeting.completed → agent proposes entity-graph diff → human-signed merge (#24)

### DIFF
--- a/deploy/compose/Makefile
+++ b/deploy/compose/Makefile
@@ -18,10 +18,12 @@ BUILD_TAG := $(VERSION)-$(shell date +%y%m%d-%H%M)
 DOCKERHUB_USER ?= vexaai
 
 # All images that get built and published.
-# agent-api remains NO-SHIP for v0.10.x (see docker-compose.yml); do not
-# promote a non-deployed image to :dev/:latest as part of public releases.
-IMAGES := api-gateway admin-api runtime-api meeting-api mcp dashboard tts-service vexa-lite
+# ei-lineage (#24): agent-api ships in compose again (meeting.completed
+# consumer + sign API), and vexa-agent is the sidecar image runtime-api
+# launches for org agent containers — both build and publish with the set.
+IMAGES := api-gateway admin-api runtime-api meeting-api mcp dashboard tts-service vexa-lite agent-api
 BOT_IMAGE := vexa-bot
+AGENT_SIDECAR_IMAGE := vexa-agent
 
 -include $(ENV_FILE)
 
@@ -171,7 +173,13 @@ build-transcript-rendering:
 	@echo "Building transcript-rendering package..."
 	@cd $(ROOT)/packages/transcript-rendering && npm install && npm run build
 
-build: check_docker build-bot-image build-transcript-rendering build-lite
+# ei-lineage (#24): the agent sidecar image (agent CLI + git) launched by
+# runtime-api's `agent` profile for org agent containers. Repo-root context.
+build-agent-image: check_docker
+	@echo "Building $(DOCKERHUB_USER)/$(AGENT_SIDECAR_IMAGE):$(BUILD_TAG)..."
+	docker build --platform linux/amd64 -t $(DOCKERHUB_USER)/$(AGENT_SIDECAR_IMAGE):$(BUILD_TAG) -f $(ROOT)/services/vexa-agent/Dockerfile $(ROOT)
+
+build: check_docker build-bot-image build-agent-image build-transcript-rendering build-lite
 	@echo "Building all images with tag: $(BUILD_TAG)"
 	@# v0.10.5.3 Pack D-1 follow-up: VEXA_VERSION + VEXA_RELEASE_DATE are
 	@# read by docker-compose.yml's dashboard service `args:` block to feed
@@ -203,6 +211,11 @@ up: check_docker preflight
 	if ! docker image inspect $$BOT_IMG > /dev/null 2>&1; then \
 		echo "Pulling bot image: $$BOT_IMG..."; \
 		docker pull $$BOT_IMG; \
+	fi; \
+	AGENT_IMG=$${AGENT_IMAGE:-$(DOCKERHUB_USER)/$(AGENT_SIDECAR_IMAGE):$$BOT_TAG}; \
+	if ! docker image inspect $$AGENT_IMG > /dev/null 2>&1; then \
+		echo "Pulling agent image: $$AGENT_IMG..."; \
+		docker pull $$AGENT_IMG || echo "  ⚠ agent image $$AGENT_IMG unavailable — org agent containers will fail until pulled"; \
 	fi; \
 	if grep -qE '^LOCAL_TRANSCRIPTION=true' $(ENV_FILE) 2>/dev/null; then \
 		echo "LOCAL_TRANSCRIPTION=true — starting transcription-service..."; \
@@ -377,7 +390,7 @@ publish: check_docker
 	fi
 	@TAG=$$(cat $(LAST_TAG_FILE)); \
 	echo "Publishing all images with tag: $$TAG"; \
-	for img in $(IMAGES) $(BOT_IMAGE); do \
+	for img in $(IMAGES) $(BOT_IMAGE) $(AGENT_SIDECAR_IMAGE); do \
 		echo "  Pushing $(DOCKERHUB_USER)/$$img:$$TAG..."; \
 		docker push $(DOCKERHUB_USER)/$$img:$$TAG; \
 		echo "  Tagging $(DOCKERHUB_USER)/$$img:dev → $$TAG"; \
@@ -398,7 +411,7 @@ promote-staging: check_docker
 		fi; \
 	fi; \
 	echo "Promoting $$TAG_TO_USE → :staging"; \
-	for img in $(IMAGES) $(BOT_IMAGE); do \
+	for img in $(IMAGES) $(BOT_IMAGE) $(AGENT_SIDECAR_IMAGE); do \
 		echo "  $(DOCKERHUB_USER)/$$img:staging → $$TAG_TO_USE"; \
 		docker pull $(DOCKERHUB_USER)/$$img:$$TAG_TO_USE; \
 		docker tag $(DOCKERHUB_USER)/$$img:$$TAG_TO_USE $(DOCKERHUB_USER)/$$img:staging; \
@@ -417,7 +430,7 @@ promote-latest: check_docker
 		fi; \
 	fi; \
 	echo "Promoting $$TAG_TO_USE → :latest"; \
-	for img in $(IMAGES) $(BOT_IMAGE); do \
+	for img in $(IMAGES) $(BOT_IMAGE) $(AGENT_SIDECAR_IMAGE); do \
 		echo "  $(DOCKERHUB_USER)/$$img:latest → $$TAG_TO_USE"; \
 		docker pull $(DOCKERHUB_USER)/$$img:$$TAG_TO_USE; \
 		docker tag $(DOCKERHUB_USER)/$$img:$$TAG_TO_USE $(DOCKERHUB_USER)/$$img:latest; \

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -126,7 +126,9 @@ services:
       - "127.0.0.1:${RUNTIME_API_PORT:-8090}:8090"
     environment:
       - DOCKER_NETWORK=${COMPOSE_PROJECT_NAME:-vexa}_vexa
-      - AGENT_IMAGE=${AGENT_IMAGE}
+      # ei-lineage (#24): the agent profile must resolve to a real image now
+      # that agent-api creates org agent containers through runtime-api.
+      - AGENT_IMAGE=${AGENT_IMAGE:-vexaai/vexa-agent:${IMAGE_TAG}}
       - BROWSER_IMAGE=${BROWSER_IMAGE}
       - REDIS_URL=redis://redis:6379
       - TRANSCRIPTION_SERVICE_URL=${TRANSCRIPTION_SERVICE_URL:-}
@@ -161,46 +163,66 @@ services:
       - vexa
     restart: unless-stopped
 
-  # agent-api: NO-SHIP for 0.10 — not included in release
-  # agent-api:
-  #   build:
-  #     context: ../..
-  #     dockerfile: services/agent-api/Dockerfile
-  #   image: vexaai/agent-api:${IMAGE_TAG}
-  #   ports:
-  #     - "${AGENT_API_PORT:-8100}:8100"
-  #   environment:
-  #     - DOCKER_NETWORK=${COMPOSE_PROJECT_NAME:-vexa}_vexa
-  #     - AGENT_IMAGE=${AGENT_IMAGE:-vexaai/vexa-agent:${IMAGE_TAG}}
-  #     - STORAGE_BACKEND=s3
-  #     - S3_ENDPOINT=http://minio:9000
-  #     - S3_ACCESS_KEY=${MINIO_ACCESS_KEY:-vexa-access-key}
-  #     - S3_SECRET_KEY=${MINIO_SECRET_KEY:-vexa-secret-key}
-  #     - S3_BUCKET=${MINIO_BUCKET:-vexa}
-  #     - CLAUDE_CREDENTIALS_PATH=${CLAUDE_CREDENTIALS_PATH}
-  #     - CLAUDE_JSON_PATH=${CLAUDE_JSON_PATH}
-  #     - IDLE_TIMEOUT=${IDLE_TIMEOUT:-300}
-  #     - REDIS_URL=redis://redis:6379
-  #     - RUNTIME_API_URL=http://runtime-api:8090
-  #     - ADMIN_API_URL=http://admin-api:8001
-  #     - ADMIN_API_TOKEN=${ADMIN_TOKEN:-vexa-admin-token}
-  #     - INTERNAL_API_SECRET=${INTERNAL_API_SECRET:-vexa-internal-secret}
-  #     - AGENT_API_INTERNAL_URL=http://agent-api:8100
-  #     - API_KEY=${BOT_API_TOKEN:-}
-  #     - BOT_API_TOKEN=${BOT_API_TOKEN:-}
-  #     - LOG_LEVEL=${LOG_LEVEL:-INFO}
-  #   volumes:
-  #     - /var/run/docker.sock:/var/run/docker.sock
-  #   depends_on:
-  #     minio-init:
-  #       condition: service_completed_successfully
-  #     redis:
-  #       condition: service_started
-  #     runtime-api:
-  #       condition: service_started
-  #   networks:
-  #     - vexa
-  #   restart: unless-stopped
+  # agent-api: re-enabled by pack ei-lineage (#24) — consumes meeting.completed
+  # from POST_MEETING_HOOKS, owns the per-org knowledge workspaces (git repos on
+  # the agent-workspaces volume) and serves the sign API (frozen contract v1).
+  # Safe by default: the org-level EI flag (user.data.ei.enabled) is OFF unless
+  # an admin turns it on, so no agent runs (and no token burn) happen on
+  # existing deployments.
+  agent-api:
+    build:
+      context: ../..
+      dockerfile: services/agent-api/Dockerfile
+    image: vexaai/agent-api:${IMAGE_TAG}
+    mem_limit: 1g
+    ports:
+      - "127.0.0.1:${AGENT_API_PORT:-8100}:8100"
+    environment:
+      - DOCKER_NETWORK=${COMPOSE_PROJECT_NAME:-vexa}_vexa
+      - AGENT_IMAGE=${AGENT_IMAGE:-vexaai/vexa-agent:${IMAGE_TAG}}
+      - STORAGE_BACKEND=s3
+      - S3_ENDPOINT=http://minio:9000
+      - S3_ACCESS_KEY=${MINIO_ACCESS_KEY:-vexa-access-key}
+      - S3_SECRET_KEY=${MINIO_SECRET_KEY:-vexa-secret-key}
+      - S3_BUCKET=${MINIO_BUCKET:-vexa}
+      - CLAUDE_CREDENTIALS_PATH=${CLAUDE_CREDENTIALS_PATH}
+      - CLAUDE_JSON_PATH=${CLAUDE_JSON_PATH}
+      - ANTHROPIC_API_KEY=${ANTHROPIC_API_KEY:-}
+      - IDLE_TIMEOUT=${IDLE_TIMEOUT:-300}
+      - REDIS_URL=redis://redis:6379
+      - RUNTIME_API_URL=http://runtime-api:8090
+      - ADMIN_API_URL=http://admin-api:8001
+      - ADMIN_API_TOKEN=${ADMIN_TOKEN:-changeme}
+      - INTERNAL_API_SECRET=${INTERNAL_API_SECRET:-vexa-internal-secret}
+      - AGENT_API_INTERNAL_URL=http://agent-api:8100
+      - API_KEY=${BOT_API_TOKEN:-}
+      - BOT_API_TOKEN=${BOT_API_TOKEN:-}
+      # ei-lineage (#24)
+      - TRANSCRIPTION_COLLECTOR_URL=http://meeting-api:8080
+      - EI_WORKSPACES_PATH=/workspaces
+      - EI_AGENT_CMD=${EI_AGENT_CMD:-}
+      - EI_AGENT_TIMEOUT=${EI_AGENT_TIMEOUT:-900}
+      - LOG_LEVEL=${LOG_LEVEL:-INFO}
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - agent-workspaces:/workspaces
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8100/health')"]
+      interval: 30s
+      timeout: 5s
+      retries: 3
+      start_period: 15s
+    init: true
+    depends_on:
+      minio-init:
+        condition: service_completed_successfully
+      redis:
+        condition: service_started
+      runtime-api:
+        condition: service_started
+    networks:
+      - vexa
+    restart: unless-stopped
 
   api-gateway:
     build:
@@ -266,10 +288,11 @@ services:
       - BOT_IMAGE_NAME=${BROWSER_IMAGE}
       - DOCKER_NETWORK=${COMPOSE_PROJECT_NAME:-vexa}_vexa
       - TTS_SERVICE_URL=http://tts-service:8002
-      # agent-api is not shipped in this compose profile. Operators can opt in
-      # with POST_MEETING_HOOKS, but the default must not point at a disabled
-      # service or every completed meeting emits DNS errors before handoff.
-      - POST_MEETING_HOOKS=${POST_MEETING_HOOKS:-}
+      # ei-lineage (#24): agent-api ships in this profile again, so the default
+      # hook target is its meeting.completed consumer (the org-level EI flag,
+      # default OFF, keeps it inert). Operators can still override/extend the
+      # comma-separated target list.
+      - POST_MEETING_HOOKS=${POST_MEETING_HOOKS:-http://agent-api:8100/internal/webhooks/meeting-completed}
       - TRANSCRIPTION_COLLECTOR_URL=http://meeting-api:8080
       - STORAGE_BACKEND=${STORAGE_BACKEND:-minio}
       - MINIO_ENDPOINT=${MINIO_ENDPOINT:-minio:9000}
@@ -441,6 +464,8 @@ volumes:
   minio-data:
   recordings-data:
   tts-voices:
+  # ei-lineage (#24): per-org knowledge workspaces (git repos), one dir per org.
+  agent-workspaces:
 
 networks:
   vexa:

--- a/deploy/env-example
+++ b/deploy/env-example
@@ -65,5 +65,16 @@ MINIO_SECURE=false
 CLAUDE_CREDENTIALS_PATH=
 CLAUDE_JSON_PATH=
 
-# Billing hooks (optional — for hosted service)
-# POST_MEETING_HOOKS=https://your-billing-webhook
+# Enterprise Intelligence (ei-lineage #24) — agent provider/model via env ONLY.
+# The org agent containers default to the in-repo vexa-agent image; override
+# image or agent command for other providers/CLIs. Per-org settings live in
+# user.data.ei (enabled flag — default OFF, org_id, agent_cli, model, env).
+# AGENT_IMAGE=vexaai/vexa-agent:latest
+# ANTHROPIC_API_KEY=
+# EI_AGENT_CMD=
+# EI_AGENT_TIMEOUT=900
+
+# Post-meeting hooks (comma-separated). Default (set in docker-compose.yml)
+# points at agent-api's meeting.completed consumer; append your own targets
+# (e.g. billing) here if needed.
+# POST_MEETING_HOOKS=http://agent-api:8100/internal/webhooks/meeting-completed,https://your-billing-webhook

--- a/services/agent-api/Dockerfile
+++ b/services/agent-api/Dockerfile
@@ -2,7 +2,9 @@ FROM python:3.11-slim
 
 WORKDIR /app
 
-RUN apt-get update && apt-get install -y --no-install-recommends gcc curl ca-certificates \
+# git: ei-lineage (#24) manages the per-org knowledge workspaces (git repos on
+# the /workspaces volume) from inside this service.
+RUN apt-get update && apt-get install -y --no-install-recommends gcc curl ca-certificates git \
     && install -m 0755 -d /etc/apt/keyrings \
     && curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc \
     && chmod a+r /etc/apt/keyrings/docker.asc \
@@ -14,5 +16,9 @@ COPY services/agent-api/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY services/agent-api .
+
+# Org workspace seed template (ei-lineage #24) — synthetic content only.
+# Copied to /workspaces/<org>/repo on an org's first meeting.completed event.
+# (Already included by the COPY above; pinned env in compose: EI_WORKSPACE_SEED_PATH.)
 
 CMD ["uvicorn", "agent_api.main:app", "--host", "0.0.0.0", "--port", "8100"]

--- a/services/agent-api/agent_api/config.py
+++ b/services/agent-api/agent_api/config.py
@@ -53,3 +53,16 @@ AGENT_STREAM_FORMAT = os.getenv("AGENT_STREAM_FORMAT", "stream-json")
 
 # CORS
 CORS_ORIGINS = os.getenv("CORS_ORIGINS", "*").split(",")
+
+# ── Enterprise-Intelligence lineage (pack ei-lineage, issue #24) ───────────
+# Transcript source — meeting-api serves the collector's internal endpoint.
+TRANSCRIPTION_COLLECTOR_URL = os.getenv("TRANSCRIPTION_COLLECTOR_URL", "http://meeting-api:8080")
+# Org knowledge workspaces (git repos) live on a volume, one dir per org.
+EI_WORKSPACES_PATH = os.getenv("EI_WORKSPACES_PATH", "/workspaces")
+# Seed template baked into the image (synthetic content only).
+EI_WORKSPACE_SEED_PATH = os.getenv("EI_WORKSPACE_SEED_PATH", "/app/workspace-seed")
+# Optional full agent command override (provider via env only — no hardcoding).
+# When empty, the command is built from AGENT_CLI/AGENT_ALLOWED_TOOLS/DEFAULT_MODEL.
+EI_AGENT_CMD = os.getenv("EI_AGENT_CMD", "")
+# Wall-clock budget for one proposal agent run (seconds).
+EI_AGENT_TIMEOUT = int(os.getenv("EI_AGENT_TIMEOUT", "900"))

--- a/services/agent-api/agent_api/lineage.py
+++ b/services/agent-api/agent_api/lineage.py
@@ -1,0 +1,716 @@
+"""Enterprise-Intelligence lineage — meeting.completed → agent proposal → human-signed merge.
+
+Pack ei-lineage (issue #24, epic #21). The missing link between meeting-api's
+POST_MEETING_HOOKS delivery seam and the agent runtime:
+
+  meeting.completed envelope (consumed, never re-transported)
+    → resolve user → org EI config (org-level enable flag, default OFF)
+    → claim the meeting (duplicate-delivery-safe, #330 receiving-side lesson)
+    → ensure the org's seeded knowledge git repo (workspace, one per org)
+    → ensure the org's agent container (runtime-api)
+    → agent runs with workspace clone + transcript
+    → proposal branch  meeting/<meeting-id>  appears in the org repo
+       ONLY after a fully successful run (crash → no partial branch)
+    → sign API (frozen contract v1): list / diff / sign(merge) / reject
+
+Frozen sign-API contract v1 (P2-signed on issue #24 — #25 builds against it):
+
+  GET  /api/proposals?org=<org_id>       -> 200 [{id, meeting_id, meeting_title,
+                                                  created_at, branch, summary, files_changed}]
+  GET  /api/proposals/{id}/diff          -> 200 {proposal_id, files: [{path,
+                                                  status: added|modified, before, after, patch}]}
+  POST /api/proposals/{id}/sign          -> 200 {merged: true, merge_commit}
+                                            (idempotent; 409 if already merged/rejected)
+  POST /api/proposals/{id}/reject {note} -> 200 {closed: true}  (note required)
+
+State:
+  - Git (the org workspace repo on a volume) is the source of truth for content:
+    main branch + proposal branches. Nothing reaches main except via /sign.
+  - Redis carries run/claim status (`ei:claim:*`) and proposal metadata
+    (`ei:proposal:*`, `ei:org:*:proposals`).
+
+Provider-agnostic by construction: the agent invocation is built from env
+(AGENT_CLI / EI_AGENT_CMD / DEFAULT_MODEL) with an optional per-org override in
+the org's EI config (`user.data.ei.agent_cli`) — the same admin-controlled seam
+that already injects per-user container env. No provider is hardcoded.
+"""
+
+import asyncio
+import io
+import json
+import logging
+import os
+import re
+import shlex
+import tarfile
+import time
+import uuid
+from datetime import datetime, timezone
+from typing import Any, Optional
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, Field
+
+from agent_api import config
+from agent_api.auth import require_api_key
+
+logger = logging.getLogger("agent_api.lineage")
+
+router = APIRouter()
+
+# Module singletons, set once from main.startup() via configure().
+_redis: Any = None
+_cm: Any = None
+
+# Per-org asyncio locks serializing git mutations on the org repo.
+_org_locks: dict[str, asyncio.Lock] = {}
+
+# Background proposal tasks (kept referenced so they are not GC'd).
+_tasks: set = set()
+
+_GIT_IDENT = ["-c", "user.name=Vexa EI", "-c", "user.email=ei-agent@vexa.ai"]
+_ORG_RE = re.compile(r"[^a-z0-9_-]+")
+
+CLAIM_RUNNING = "running"
+CLAIM_PROPOSED = "proposed"
+CLAIM_FAILED = "failed"
+
+# Atomic claim: take the claim if absent OR if the previous run failed
+# (safe retry). Never re-claim a running/proposed meeting — exactly one
+# proposal per meeting (#330 receiving-side lesson, claim BEFORE run).
+_CLAIM_LUA = """
+local cur = redis.call('GET', KEYS[1])
+if cur then
+  local ok, prev = pcall(cjson.decode, cur)
+  if ok and prev['status'] == 'failed' then
+    redis.call('SET', KEYS[1], ARGV[1])
+    return 1
+  end
+  return 0
+end
+redis.call('SET', KEYS[1], ARGV[1])
+return 1
+"""
+
+
+def configure(redis, cm) -> None:
+    """Wire module singletons at app startup."""
+    global _redis, _cm
+    _redis = redis
+    _cm = cm
+
+
+def _org_lock(org_id: str) -> asyncio.Lock:
+    if org_id not in _org_locks:
+        _org_locks[org_id] = asyncio.Lock()
+    return _org_locks[org_id]
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def sanitize_org_id(raw: str) -> str:
+    org = _ORG_RE.sub("-", str(raw).strip().lower()).strip("-")
+    if not org:
+        raise ValueError(f"Unusable org id: {raw!r}")
+    return org
+
+
+# ── Paths ──────────────────────────────────────────────────────────────────
+
+
+def org_repo_path(org_id: str) -> str:
+    return os.path.join(config.EI_WORKSPACES_PATH, org_id, "repo")
+
+
+def _runs_dir(org_id: str) -> str:
+    return os.path.join(config.EI_WORKSPACES_PATH, org_id, ".runs")
+
+
+# ── Subprocess helpers ─────────────────────────────────────────────────────
+
+
+async def _run(argv: list[str], cwd: Optional[str] = None, stdin: Optional[bytes] = None,
+               timeout: int = 120) -> tuple[int, bytes]:
+    """Run a local subprocess, return (rc, combined output)."""
+    proc = await asyncio.create_subprocess_exec(
+        *argv,
+        cwd=cwd,
+        stdin=asyncio.subprocess.PIPE if stdin is not None else None,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.STDOUT,
+    )
+    try:
+        out, _ = await asyncio.wait_for(proc.communicate(input=stdin), timeout=timeout)
+    except asyncio.TimeoutError:
+        proc.kill()
+        await proc.wait()
+        return 124, b"timeout"
+    return proc.returncode or 0, out or b""
+
+
+async def _git(args: list[str], cwd: Optional[str] = None, check: bool = True,
+               timeout: int = 60) -> str:
+    rc, out = await _run(["git", *_GIT_IDENT, *args], cwd=cwd, timeout=timeout)
+    text = out.decode(errors="replace").strip()
+    if check and rc != 0:
+        raise RuntimeError(f"git {' '.join(args[:3])} failed (rc={rc}): {text[:500]}")
+    return text
+
+
+async def _dexec(container: str, argv: list[str], stdin: Optional[bytes] = None,
+                 timeout: int = 120) -> tuple[int, bytes]:
+    """docker exec into the agent container."""
+    cmd = ["docker", "exec"]
+    if stdin is not None:
+        cmd.append("-i")
+    cmd += [container, *argv]
+    return await _run(cmd, stdin=stdin, timeout=timeout)
+
+
+# ── Tar transfer (agent-api FS ⇄ agent container) ──────────────────────────
+
+
+def _tar_dir(path: str) -> bytes:
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz") as tf:
+        for entry in sorted(os.listdir(path)):
+            tf.add(os.path.join(path, entry), arcname=entry)
+    return buf.getvalue()
+
+
+def _untar_to(data: bytes, path: str) -> None:
+    os.makedirs(path, exist_ok=True)
+    with tarfile.open(fileobj=io.BytesIO(data), mode="r:gz") as tf:
+        tf.extractall(path)  # noqa: S202 — archive produced by our own container
+
+
+# ── EI org config (fresh fetch — flag flips must take effect immediately) ──
+
+
+async def resolve_ei_config(user_id) -> Optional[dict]:
+    """Fetch user.data.ei from admin-api. Returns None when EI is not enabled.
+
+    Never cached: the org-level enable flag and agent settings must be
+    re-read on every event (default OFF — absent key means disabled).
+    """
+    try:
+        int_id = int(user_id)
+    except (TypeError, ValueError):
+        logger.info(f"EI: non-numeric user_id {user_id!r} — treating as disabled")
+        return None
+
+    headers = {"X-Admin-API-Key": config.ADMIN_API_TOKEN} if config.ADMIN_API_TOKEN else {}
+    async with httpx.AsyncClient(base_url=config.ADMIN_API_URL, timeout=10,
+                                 headers=headers) as client:
+        resp = await client.get(f"/admin/users/{int_id}")
+    if resp.status_code == 404:
+        logger.info(f"EI: user {int_id} not found — treating as disabled")
+        return None
+    if resp.status_code != 200:
+        raise RuntimeError(f"admin-api returned {resp.status_code} for user {int_id}")
+
+    data = resp.json().get("data") or {}
+    ei = data.get("ei") or {}
+    if not ei.get("enabled"):
+        return None
+    org_raw = ei.get("org_id") or f"user-{int_id}"
+    ei = dict(ei)
+    ei["org_id"] = sanitize_org_id(org_raw)
+    return ei
+
+
+# ── Claim / run-status (Redis) ─────────────────────────────────────────────
+
+
+def _claim_key(org_id: str, meeting_id) -> str:
+    return f"ei:claim:{org_id}:{meeting_id}"
+
+
+async def claim_meeting(org_id: str, meeting_id, event_id: str) -> bool:
+    """Atomically claim a meeting for an agent run. True = we own the run."""
+    value = json.dumps({
+        "status": CLAIM_RUNNING,
+        "event_id": event_id,
+        "updated_at": _now(),
+    })
+    res = await _redis.eval(_CLAIM_LUA, 1, _claim_key(org_id, meeting_id), value)
+    return bool(res)
+
+
+async def set_claim(org_id: str, meeting_id, status: str, **extra) -> None:
+    raw = await _redis.get(_claim_key(org_id, meeting_id))
+    record = json.loads(raw) if raw else {}
+    record.update(status=status, updated_at=_now(), **extra)
+    await _redis.set(_claim_key(org_id, meeting_id), json.dumps(record))
+
+
+async def get_claim(org_id: str, meeting_id) -> Optional[dict]:
+    raw = await _redis.get(_claim_key(org_id, meeting_id))
+    return json.loads(raw) if raw else None
+
+
+# ── Proposal store (Redis metadata; git is the content truth) ──────────────
+
+
+async def _save_proposal(record: dict) -> None:
+    pid = record["id"]
+    await _redis.set(f"ei:proposal:{pid}", json.dumps(record))
+    await _redis.sadd(f"ei:org:{record['org_id']}:proposals", pid)
+
+
+async def get_proposal(pid: str) -> Optional[dict]:
+    raw = await _redis.get(f"ei:proposal:{pid}")
+    return json.loads(raw) if raw else None
+
+
+async def list_org_proposals(org_id: str) -> list[dict]:
+    pids = await _redis.smembers(f"ei:org:{org_id}:proposals")
+    records = []
+    for pid in pids:
+        rec = await get_proposal(pid)
+        if rec:
+            records.append(rec)
+    records.sort(key=lambda r: r.get("created_at", ""))
+    return records
+
+
+# ── Workspace (seeded git repo per org) ────────────────────────────────────
+
+
+async def ensure_workspace(org_id: str) -> str:
+    """Ensure the org's knowledge repo exists; seed it on first use.
+
+    Seed template ships in the agent-api image (services/agent-api/workspace-seed,
+    synthetic content only). Returns the repo path.
+    """
+    repo = org_repo_path(org_id)
+    async with _org_lock(org_id):
+        if os.path.isdir(os.path.join(repo, ".git")):
+            return repo
+        seed = config.EI_WORKSPACE_SEED_PATH
+        if not os.path.isdir(seed):
+            raise RuntimeError(f"workspace seed missing at {seed}")
+        os.makedirs(repo, exist_ok=True)
+        rc, out = await _run(["cp", "-a", f"{seed}/.", repo])
+        if rc != 0:
+            raise RuntimeError(f"seed copy failed: {out.decode(errors='replace')[:300]}")
+        await _git(["init", "-b", "main"], cwd=repo)
+        await _git(["add", "-A"], cwd=repo)
+        await _git(["commit", "-m", f"seed: org workspace for {org_id}"], cwd=repo)
+        logger.info(f"EI: seeded workspace for org {org_id} at {repo}")
+        return repo
+
+
+async def _branch_exists(repo: str, branch: str) -> bool:
+    rc, _ = await _run(["git", "-C", repo, "rev-parse", "--verify", "--quiet",
+                        f"refs/heads/{branch}"])
+    return rc == 0
+
+
+# ── Transcript fetch ───────────────────────────────────────────────────────
+
+
+async def fetch_transcript(meeting_id) -> str:
+    """Best-effort transcript fetch from the collector's internal endpoint."""
+    url = f"{config.TRANSCRIPTION_COLLECTOR_URL}/internal/transcripts/{meeting_id}"
+    headers = ({"X-Internal-Secret": config.INTERNAL_API_SECRET}
+               if config.INTERNAL_API_SECRET else {})
+    try:
+        async with httpx.AsyncClient(timeout=30) as client:
+            resp = await client.get(url, headers=headers)
+        if resp.status_code != 200:
+            logger.warning(f"EI: transcript fetch for meeting {meeting_id} -> "
+                           f"{resp.status_code}; continuing with empty transcript")
+            return ""
+        segments = resp.json() or []
+    except Exception as e:
+        logger.warning(f"EI: transcript fetch failed for meeting {meeting_id}: {e}")
+        return ""
+    lines = []
+    for seg in segments:
+        speaker = (seg.get("speaker") or "Unknown").strip()
+        text = (seg.get("text") or "").strip()
+        if text:
+            lines.append(f"{speaker}: {text}")
+    return "\n".join(lines)
+
+
+# ── Agent invocation ───────────────────────────────────────────────────────
+
+
+def _agent_command(ei: dict) -> str:
+    """Build the agent CLI invocation prefix. The prompt is appended as ONE
+    shell-quoted argument. Resolution order (most specific wins, no provider
+    hardcoded): org EI config `agent_cli` → env EI_AGENT_CMD → env AGENT_CLI
+    (+ AGENT_ALLOWED_TOOLS / model from org config or DEFAULT_MODEL)."""
+    if ei.get("agent_cli"):
+        return str(ei["agent_cli"])
+    if config.EI_AGENT_CMD:
+        return config.EI_AGENT_CMD
+    parts = [config.AGENT_CLI, "--allowedTools", shlex.quote(config.AGENT_ALLOWED_TOOLS)]
+    model = ei.get("model") or config.DEFAULT_MODEL
+    if model:
+        parts += ["--model", shlex.quote(str(model))]
+    parts.append("-p")
+    return " ".join(parts)
+
+
+def _build_prompt(meeting_id, meeting: dict) -> str:
+    title = meeting.get("title") or f"{meeting.get('platform', 'meeting')} {meeting_id}"
+    return f"""A meeting has completed and its transcript must be folded into this org's knowledge graph.
+
+Meeting: {title} (id {meeting_id})
+Transcript: ../input/transcript.md  (read-only input — do NOT copy it into the repo)
+Metadata:   ../input/meeting.json
+
+You are in the org knowledge repository working tree. First read AGENT.md at the
+repository root and follow its conventions exactly (dated confidence-scored appends,
+single-write-path regions, [[wikilinks]]). Then:
+
+1. Create the meeting artifact graph/kg/entities/meetings/{meeting_id}-<slug>.md
+   from templates/meeting._template.md.
+2. For every person/company that matters in the meeting, update (or create from the
+   matching template) their entity file under graph/kg/entities/, appending a dated,
+   confidence-scored entry inside the routine-updates region only.
+3. Link artifacts with [[wikilinks]].
+
+Modify files only inside this repository working tree. Do not run git commands —
+branching and commits happen outside the agent.
+"""
+
+
+async def _touch_loop(container: str) -> None:
+    """Keep runtime-api's idle reaper away while a long agent run is active."""
+    while True:
+        await asyncio.sleep(60)
+        try:
+            await _cm._touch(container)
+        except Exception:
+            pass
+
+
+# ── The proposal pipeline ──────────────────────────────────────────────────
+
+
+async def run_proposal(org_id: str, meeting_id, ei: dict, envelope: dict) -> None:
+    """Background pipeline: workspace → container → agent → proposal branch.
+
+    Crash-safety invariant: the proposal branch is fetched into the org repo
+    only after the agent run succeeded AND produced a schema-conforming commit
+    in an isolated working clone. Any failure before that leaves the org repo
+    untouched; the claim flips to `failed` (visible status, safe retry).
+    """
+    meeting = (envelope.get("data") or {}).get("meeting") or {}
+    branch = f"meeting/{meeting_id}"
+    run_id = f"{meeting_id}-{int(time.time())}"
+    run_dir = os.path.join(_runs_dir(org_id), run_id)
+    container_run_root = f"/tmp/ei-run-{org_id}-{meeting_id}"
+    container = None
+    touch_task = None
+    try:
+        repo = await ensure_workspace(org_id)
+
+        # Idempotency belt-and-braces: proposal branch already in the repo.
+        if await _branch_exists(repo, branch):
+            logger.info(f"EI: branch {branch} already exists for org {org_id} — skipping run")
+            await set_claim(org_id, meeting_id, CLAIM_PROPOSED)
+            return
+
+        transcript = await fetch_transcript(meeting_id)
+
+        # Working clone — the agent never touches the org repo directly.
+        os.makedirs(run_dir, exist_ok=True)
+        async with _org_lock(org_id):
+            await _git(["clone", "--branch", "main", "--single-branch", repo,
+                        os.path.join(run_dir, "repo")])
+        input_dir = os.path.join(run_dir, "input")
+        os.makedirs(input_dir, exist_ok=True)
+        with open(os.path.join(input_dir, "transcript.md"), "w") as f:
+            f.write(transcript or "(no transcript available)\n")
+        with open(os.path.join(input_dir, "meeting.json"), "w") as f:
+            json.dump(meeting, f, indent=2)
+
+        # Org agent container via runtime-api (one per org — tenant isolation).
+        org_env = ei.get("env") or {}
+        container = await _cm.ensure_container(
+            f"ei-{org_id}", session_id="ei",
+            config={"env": org_env} if org_env else {},
+        )
+
+        # Ship the working clone + inputs into the container.
+        payload = _tar_dir(run_dir)
+        rc, out = await _dexec(
+            container,
+            ["sh", "-c",
+             f"rm -rf {container_run_root} && mkdir -p {container_run_root} "
+             f"&& tar -xz -C {container_run_root}"],
+            stdin=payload, timeout=120,
+        )
+        if rc != 0:
+            raise RuntimeError(f"workspace transfer failed: {out.decode(errors='replace')[:300]}")
+
+        # Run the agent.
+        prompt = _build_prompt(meeting_id, meeting)
+        agent_cmd = _agent_command(ei)
+        shell_cmd = (
+            f"cd {container_run_root}/repo && "
+            f"EI_MEETING_ID={shlex.quote(str(meeting_id))} EI_ORG_ID={shlex.quote(org_id)} "
+            f"{agent_cmd} {shlex.quote(prompt)}"
+        )
+        logger.info(f"EI: agent run starting for org={org_id} meeting={meeting_id} "
+                    f"container={container}")
+        touch_task = asyncio.create_task(_touch_loop(container))
+        rc, out = await _dexec(container, ["bash", "-c", shell_cmd],
+                               timeout=config.EI_AGENT_TIMEOUT)
+        touch_task.cancel()
+        touch_task = None
+        tail = out.decode(errors="replace")[-2000:]
+        if rc != 0:
+            raise RuntimeError(f"agent run failed (rc={rc}): {tail[:500]}")
+
+        # Pull the (possibly modified) clone back out.
+        rc, data = await _dexec(container, ["tar", "-cz", "-C", container_run_root, "repo"],
+                                timeout=120)
+        if rc != 0:
+            raise RuntimeError("workspace retrieval failed")
+        out_dir = os.path.join(run_dir, "out")
+        _untar_to(data, out_dir)
+        out_repo = os.path.join(out_dir, "repo")
+
+        # Validate + commit the proposal in the isolated clone.
+        await _git(["checkout", "-b", branch], cwd=out_repo)
+        await _git(["add", "-A"], cwd=out_repo)
+        changed = await _git(["diff", "--cached", "--name-status"], cwd=out_repo)
+        if not changed.strip():
+            raise RuntimeError("agent run produced no changes")
+        new_meeting_artifacts = [
+            line.split("\t", 1)[1] for line in changed.splitlines()
+            if line.startswith("A") and "graph/kg/entities/meetings/" in line
+        ]
+        if not new_meeting_artifacts:
+            raise RuntimeError(
+                "agent run produced changes but no new meeting artifact under "
+                "graph/kg/entities/meetings/ — rejecting non-conforming proposal")
+        await _git(["commit", "-m", f"proposal: meeting {meeting_id}"], cwd=out_repo)
+
+        # Atomic publication: the branch lands in the org repo in one fetch.
+        async with _org_lock(org_id):
+            if await _branch_exists(repo, branch):
+                raise RuntimeError(f"branch {branch} appeared concurrently")
+            await _git(["fetch", out_repo, f"{branch}:{branch}"], cwd=repo)
+
+        files = [ln for ln in changed.splitlines() if ln.strip()]
+        record = {
+            "id": f"prop_{uuid.uuid4().hex[:12]}",
+            "org_id": org_id,
+            "meeting_id": meeting_id,
+            "meeting_title": meeting.get("title")
+                             or f"{meeting.get('platform', 'meeting')} {meeting_id}",
+            "created_at": _now(),
+            "branch": branch,
+            "summary": f"meeting artifact {new_meeting_artifacts[0]}"
+                       f" + {len(files) - 1} other change(s)",
+            "files_changed": len(files),
+            "status": "open",
+        }
+        await _save_proposal(record)
+        await set_claim(org_id, meeting_id, CLAIM_PROPOSED, proposal_id=record["id"])
+        logger.info(f"EI: proposal {record['id']} ({branch}) created for org {org_id}")
+
+    except Exception as e:
+        logger.error(f"EI: proposal run failed for org={org_id} meeting={meeting_id}: {e}",
+                     exc_info=True)
+        try:
+            await set_claim(org_id, meeting_id, CLAIM_FAILED, error=str(e)[:500])
+        except Exception:
+            logger.exception("EI: could not record failed claim")
+    finally:
+        if touch_task:
+            touch_task.cancel()
+        # No partial state anywhere: temp run dir + container scratch removed.
+        await _run(["rm", "-rf", run_dir])
+        if container:
+            try:
+                await _dexec(container, ["rm", "-rf", container_run_root], timeout=30)
+            except Exception:
+                pass
+
+
+# ── Event consumer ─────────────────────────────────────────────────────────
+
+
+async def handle_meeting_completed(envelope: dict) -> dict:
+    """Consume one meeting.completed envelope (POST_MEETING_HOOKS target).
+
+    Returns a status dict; raises HTTPException(503) on infrastructure errors
+    so meeting-api's outbound ledger keeps the event retryable.
+    """
+    event_type = envelope.get("event_type", "")
+    if event_type != "meeting.completed":
+        return {"status": "ignored", "detail": f"event_type {event_type!r} not consumed"}
+
+    meeting = (envelope.get("data") or {}).get("meeting") or {}
+    meeting_id = meeting.get("id")
+    user_id = meeting.get("user_id")
+    if meeting_id is None or user_id is None:
+        return {"status": "ignored", "detail": "missing meeting id/user_id"}
+
+    try:
+        ei = await resolve_ei_config(user_id)
+    except Exception as e:
+        logger.error(f"EI: cannot resolve EI config for user {user_id}: {e}")
+        raise HTTPException(503, "EI config resolution failed; retry later")
+
+    if not ei:
+        # Org-level enable flag is OFF (default) — fully inert, no state created.
+        return {"status": "inert", "detail": "EI disabled for this user/org"}
+
+    org_id = ei["org_id"]
+    event_id = envelope.get("event_id", "")
+    claimed = await claim_meeting(org_id, meeting_id, event_id)
+    if not claimed:
+        claim = await get_claim(org_id, meeting_id)
+        return {
+            "status": "duplicate",
+            "detail": f"meeting already {((claim or {}).get('status')) or 'claimed'}",
+            "org_id": org_id,
+            "meeting_id": meeting_id,
+        }
+
+    task = asyncio.create_task(run_proposal(org_id, meeting_id, ei, envelope))
+    _tasks.add(task)
+    task.add_done_callback(_tasks.discard)
+    return {"status": "accepted", "org_id": org_id, "meeting_id": meeting_id}
+
+
+# ── Sign API (frozen contract v1) ──────────────────────────────────────────
+
+
+class RejectRequest(BaseModel):
+    note: str = Field(..., min_length=1)
+
+
+async def _load_scoped(pid: str, org: Optional[str]) -> dict:
+    """Load a proposal; org-scoped — cross-org access is a 404, not a 403."""
+    record = await get_proposal(pid)
+    if not record:
+        raise HTTPException(404, "Proposal not found")
+    if org is not None and record["org_id"] != org:
+        raise HTTPException(404, "Proposal not found")
+    return record
+
+
+def _contract_shape(record: dict) -> dict:
+    return {
+        "id": record["id"],
+        "meeting_id": record["meeting_id"],
+        "meeting_title": record["meeting_title"],
+        "created_at": record["created_at"],
+        "branch": record["branch"],
+        "summary": record["summary"],
+        "files_changed": record["files_changed"],
+    }
+
+
+@router.get("/api/proposals", dependencies=[Depends(require_api_key)])
+async def list_proposals(org: str = Query(...)):
+    """List pending (open) proposals for an org."""
+    org = sanitize_org_id(org)
+    records = await list_org_proposals(org)
+    return [_contract_shape(r) for r in records if r.get("status") == "open"]
+
+
+@router.get("/api/proposals/{pid}/diff", dependencies=[Depends(require_api_key)])
+async def proposal_diff(pid: str, org: Optional[str] = Query(None)):
+    record = await _load_scoped(pid, sanitize_org_id(org) if org else None)
+    repo = org_repo_path(record["org_id"])
+    branch = record["branch"]
+    if record.get("status") == "rejected" or not await _branch_exists(repo, branch):
+        # Rejected proposals have no branch left to diff.
+        return {"proposal_id": pid, "files": []}
+
+    name_status = await _git(["diff", "--name-status", f"main...{branch}"], cwd=repo)
+    files = []
+    for line in name_status.splitlines():
+        if not line.strip():
+            continue
+        parts = line.split("\t")
+        code, path = parts[0], parts[-1]
+        status = "added" if code.startswith("A") else "modified"
+        before = ""
+        if not code.startswith("A"):
+            rc, out = await _run(["git", "-C", repo, "show", f"main:{path}"])
+            before = out.decode(errors="replace") if rc == 0 else ""
+        rc, out = await _run(["git", "-C", repo, "show", f"{branch}:{path}"])
+        after = out.decode(errors="replace") if rc == 0 else ""
+        patch = await _git(["diff", f"main...{branch}", "--", path], cwd=repo)
+        files.append({"path": path, "status": status,
+                      "before": before, "after": after, "patch": patch})
+    return {"proposal_id": pid, "files": files}
+
+
+@router.post("/api/proposals/{pid}/sign", dependencies=[Depends(require_api_key)])
+async def sign_proposal(pid: str, org: Optional[str] = Query(None)):
+    """Merge the proposal branch into the workspace main branch.
+
+    The ONLY path by which content reaches main. Idempotent in effect: a
+    repeat sign (or a sign after reject) returns 409 and never re-merges.
+    """
+    record = await _load_scoped(pid, sanitize_org_id(org) if org else None)
+    if record.get("status") != "open":
+        raise HTTPException(
+            409, f"Proposal already {record.get('status')}"
+                 + (f" (merge_commit {record['merge_commit']})"
+                    if record.get("merge_commit") else ""))
+
+    repo = org_repo_path(record["org_id"])
+    branch = record["branch"]
+    async with _org_lock(record["org_id"]):
+        if not await _branch_exists(repo, branch):
+            raise HTTPException(409, "Proposal branch is gone")
+        # The org repo's checkout stays on main and is never dirtied (runs use
+        # isolated clones), so a plain --no-ff merge is safe here.
+        await _git(["merge", "--no-ff", "-m",
+                    f"sign: merge proposal {pid} ({branch})", branch], cwd=repo)
+        merge_commit = await _git(["rev-parse", "HEAD"], cwd=repo)
+        record["status"] = "signed"
+        record["merge_commit"] = merge_commit
+        record["signed_at"] = _now()
+        await _save_proposal(record)
+    return {"merged": True, "merge_commit": merge_commit}
+
+
+@router.post("/api/proposals/{pid}/reject", dependencies=[Depends(require_api_key)])
+async def reject_proposal(pid: str, body: RejectRequest, org: Optional[str] = Query(None)):
+    """Close a proposal without merging: delete the branch, keep the note."""
+    record = await _load_scoped(pid, sanitize_org_id(org) if org else None)
+    if record.get("status") != "open":
+        raise HTTPException(409, f"Proposal already {record.get('status')}")
+
+    repo = org_repo_path(record["org_id"])
+    async with _org_lock(record["org_id"]):
+        if await _branch_exists(repo, record["branch"]):
+            await _git(["branch", "-D", record["branch"]], cwd=repo)
+        record["status"] = "rejected"
+        record["note"] = body.note
+        record["rejected_at"] = _now()
+        await _save_proposal(record)
+    return {"closed": True}
+
+
+# ── Internal status (visible run state — ops + regression checks) ──────────
+
+
+@router.get("/internal/ei/status")
+async def ei_status(org_id: str, meeting_id: str):
+    """Run/claim status for one meeting in one org. Internal surface."""
+    org_id = sanitize_org_id(org_id)
+    claim = await get_claim(org_id, meeting_id)
+    proposal = None
+    if claim and claim.get("proposal_id"):
+        proposal = await get_proposal(claim["proposal_id"])
+    return {"org_id": org_id, "meeting_id": meeting_id,
+            "claim": claim, "proposal": proposal}

--- a/services/agent-api/agent_api/main.py
+++ b/services/agent-api/agent_api/main.py
@@ -35,6 +35,7 @@ from agent_api.chat import (
     save_session_meta,
 )
 from agent_api.container_manager import ContainerManager
+from agent_api import lineage
 from agent_api import workspace
 
 logging.basicConfig(
@@ -61,6 +62,9 @@ app.add_middleware(
 )
 
 cm = ContainerManager()
+
+# Enterprise-Intelligence lineage: sign API (frozen contract v1) + run status.
+app.include_router(lineage.router)
 
 
 # ── Request / response models ──────────────────────────────────────────────
@@ -127,6 +131,9 @@ async def startup():
     logger.info("Redis connected")
 
     await cm.startup()
+
+    # EI lineage shares the app's Redis client + container manager.
+    lineage.configure(app.state.redis, cm)
 
     # Migrate legacy S3 workspace paths (workspaces/{uid}/ → workspaces/{uid}/default/)
     try:
@@ -489,13 +496,21 @@ async def workspace_save(req: UserIdRequest):
 
 @app.post("/internal/webhooks/meeting-completed")
 async def webhook_meeting_completed(request: Request):
-    """Receive post-meeting webhook from meeting-api."""
+    """Consume a meeting.completed envelope from meeting-api's POST_MEETING_HOOKS.
+
+    Pack ei-lineage (#24): claims the meeting (duplicate-delivery-safe), then
+    kicks off the proposal pipeline in the background — workspace ensure →
+    org agent container → agent run → proposal branch meeting/<id>.
+    Responds fast so the hook delivery (10s timeout) never blocks on the run.
+    Org-level enable flag default OFF: without it, this endpoint is inert.
+    """
     body = await request.json()
     event_type = body.get("event_type", "unknown")
     event_id = body.get("event_id", "?")
     meeting_id = body.get("data", {}).get("meeting", {}).get("id", "?")
     logger.info(f"[Webhook] Received {event_type} event_id={event_id} meeting={meeting_id}")
-    return {"status": "received", "event_id": event_id}
+    result = await lineage.handle_meeting_completed(body)
+    return {"event_id": event_id, **result}
 
 
 @app.get("/internal/workspace/status")

--- a/services/agent-api/tests/test_lineage.py
+++ b/services/agent-api/tests/test_lineage.py
@@ -1,0 +1,89 @@
+"""Unit tests for the EI lineage module (pack ei-lineage, issue #24).
+
+Pure-function coverage: org sanitization, provider-agnostic agent command
+resolution, frozen-contract response shaping, prompt invariants. The live
+behavior (claim/run/sign against a real stack) is covered by the compose
+regression tests3/tests/ei-lineage.sh.
+"""
+
+import pytest
+
+from agent_api import config, lineage
+
+
+# ── sanitize_org_id ────────────────────────────────────────────────────────
+
+def test_sanitize_org_id_passthrough():
+    assert lineage.sanitize_org_id("acme-corp_1") == "acme-corp_1"
+
+
+def test_sanitize_org_id_normalizes():
+    assert lineage.sanitize_org_id("Acme Corp / EU!") == "acme-corp-eu"
+
+
+def test_sanitize_org_id_rejects_empty():
+    with pytest.raises(ValueError):
+        lineage.sanitize_org_id("///")
+
+
+def test_sanitize_org_id_blocks_traversal():
+    # Path separators must never survive into workspace paths.
+    assert "/" not in lineage.sanitize_org_id("../../etc")
+    assert ".." not in lineage.sanitize_org_id("../../etc")
+
+
+# ── _agent_command (provider via env/org config only — never hardcoded) ────
+
+def test_agent_command_org_override_wins(monkeypatch):
+    monkeypatch.setattr(config, "EI_AGENT_CMD", "env-cmd -p")
+    assert lineage._agent_command({"agent_cli": "vibe run"}) == "vibe run"
+
+
+def test_agent_command_env_override(monkeypatch):
+    monkeypatch.setattr(config, "EI_AGENT_CMD", "opencode --quiet -p")
+    assert lineage._agent_command({}) == "opencode --quiet -p"
+
+
+def test_agent_command_default_built_from_agent_cli(monkeypatch):
+    monkeypatch.setattr(config, "EI_AGENT_CMD", "")
+    monkeypatch.setattr(config, "AGENT_CLI", "claude")
+    monkeypatch.setattr(config, "AGENT_ALLOWED_TOOLS", "Read,Write")
+    monkeypatch.setattr(config, "DEFAULT_MODEL", "")
+    cmd = lineage._agent_command({})
+    assert cmd.startswith("claude ")
+    assert cmd.endswith(" -p")
+    assert "Read,Write" in cmd
+    assert "--model" not in cmd
+
+
+def test_agent_command_org_model(monkeypatch):
+    monkeypatch.setattr(config, "EI_AGENT_CMD", "")
+    monkeypatch.setattr(config, "AGENT_CLI", "claude")
+    monkeypatch.setattr(config, "DEFAULT_MODEL", "")
+    cmd = lineage._agent_command({"model": "some-local-model"})
+    assert "--model some-local-model" in cmd
+
+
+# ── Frozen sign-API contract v1 shape ──────────────────────────────────────
+
+def test_contract_shape_exact_keys():
+    record = {
+        "id": "prop_abc", "org_id": "acme", "meeting_id": 7,
+        "meeting_title": "t", "created_at": "2026-06-10T00:00:00Z",
+        "branch": "meeting/7", "summary": "s", "files_changed": 2,
+        "status": "open", "internal_field": "must-not-leak",
+    }
+    shaped = lineage._contract_shape(record)
+    assert set(shaped) == {"id", "meeting_id", "meeting_title", "created_at",
+                           "branch", "summary", "files_changed"}
+    assert shaped["branch"] == "meeting/7"
+
+
+# ── Prompt invariants ──────────────────────────────────────────────────────
+
+def test_prompt_mentions_conventions_and_inputs():
+    prompt = lineage._build_prompt(42, {"platform": "google_meet"})
+    assert "AGENT.md" in prompt
+    assert "../input/transcript.md" in prompt
+    assert "graph/kg/entities/meetings/42-" in prompt
+    assert "Do not run git commands" in prompt

--- a/services/agent-api/workspace-seed/AGENT.md
+++ b/services/agent-api/workspace-seed/AGENT.md
@@ -1,0 +1,49 @@
+# Org knowledge agent — operating instructions
+
+You are this organization's knowledge agent. This file is part of the workspace and is
+versioned together with the knowledge it governs: improve it via proposals like any other
+artifact. These instructions are per-org by construction — edits here affect only this org.
+
+ALL CONTENT IN THIS SEED IS SYNTHETIC. Replace nothing by hand; the graph grows only
+through signed proposals.
+
+## Workspace layout
+
+```
+AGENT.md                          ← you are here (self-managed instructions)
+templates/                        ← one `_template` file per artifact type
+graph/
+  kg/entities/
+    people/<slug>.md              ← one file per person
+    companies/<slug>.md           ← one file per company
+    meetings/<meeting-id>-<slug>.md  ← one file per completed meeting
+  sg/                             ← org doctrine / strategy nodes
+```
+
+## Conventions (binding)
+
+1. **Templates first.** Every new artifact starts from its `templates/*._template.md`
+   file. Keep every section header from the template, even if a section is empty.
+2. **Dated, confidence-scored appends.** Routine knowledge lands as appends:
+   `- YYYY-MM-DD [conf:0.0–1.0] <fact> (source: [[meeting artifact]])`.
+   Never silently rewrite history — corrections are new dated entries.
+3. **Single write path per region.** Each entity file has exactly one
+   `<!-- routine-updates:begin -->` … `<!-- routine-updates:end -->` region.
+   Routine appends go ONLY inside it; the sections above it change only on
+   deliberate (non-routine) restructuring.
+4. **[[Wikilinks]].** Cross-reference entities and meetings with `[[double-bracket]]`
+   links using the artifact's title.
+5. **Scope.** Modify files only inside this repository. Inputs (transcript, metadata)
+   live outside the repo and are read-only. Never run git commands — branching,
+   commits and merges happen outside the agent.
+
+## Per-meeting task
+
+For each completed meeting:
+
+1. Create `graph/kg/entities/meetings/<meeting-id>-<short-slug>.md` from
+   `templates/meeting._template.md`: summary, decisions, action items, participants.
+2. For each participant/company that matters, update their entity file (create from
+   the matching template when missing) with dated confidence-scored appends citing
+   the meeting artifact.
+3. Wire everything with wikilinks (meeting ↔ people ↔ companies).

--- a/services/agent-api/workspace-seed/graph/kg/entities/companies/acme-corp.md
+++ b/services/agent-api/workspace-seed/graph/kg/entities/companies/acme-corp.md
@@ -1,0 +1,20 @@
+# Acme Corp
+
+- industry: Manufacturing (synthetic seed example)
+- relationship: customer
+- first-seen: 2026-01-05
+
+## Profile
+
+Synthetic seed entity. Acme Corp is a fictional company used only to demonstrate the
+workspace conventions.
+
+## People
+
+- [[Jane Doe]] — Head of Operations
+
+## Routine updates
+
+<!-- routine-updates:begin -->
+- 2026-01-05 [conf:1.0] Seed example entry — replace through signed proposals only. (source: seed)
+<!-- routine-updates:end -->

--- a/services/agent-api/workspace-seed/graph/kg/entities/people/jane-doe.md
+++ b/services/agent-api/workspace-seed/graph/kg/entities/people/jane-doe.md
@@ -1,0 +1,16 @@
+# Jane Doe
+
+- role: Head of Operations (synthetic seed example)
+- company: [[Acme Corp]]
+- first-seen: 2026-01-05
+
+## Profile
+
+Synthetic seed entity demonstrating the conventions: stable profile facts live here,
+routine knowledge accumulates below as dated, confidence-scored appends.
+
+## Routine updates
+
+<!-- routine-updates:begin -->
+- 2026-01-05 [conf:1.0] Seed example entry — replace through signed proposals only. (source: seed)
+<!-- routine-updates:end -->

--- a/services/agent-api/workspace-seed/graph/sg/README.md
+++ b/services/agent-api/workspace-seed/graph/sg/README.md
@@ -1,0 +1,7 @@
+# Strategy graph (sg)
+
+Org doctrine and strategy nodes live here — the durable "how we think" layer that the
+knowledge graph's entity facts hang off. One markdown node per doctrine, wikilinked from
+entities and meeting artifacts where relevant.
+
+Seed content is synthetic; grow this layer through signed proposals.

--- a/services/agent-api/workspace-seed/graph/sg/meeting-knowledge-doctrine.md
+++ b/services/agent-api/workspace-seed/graph/sg/meeting-knowledge-doctrine.md
@@ -1,0 +1,10 @@
+# Doctrine: meetings are the org's primary knowledge source
+
+(Synthetic seed node.)
+
+Every completed meeting must leave a durable trace: a meeting artifact plus entity
+updates. Knowledge that only lives in someone's head after a meeting is treated as lost.
+
+- Artifacts cite their sources; entity facts cite their meeting artifact.
+- Confidence scores make uncertainty explicit instead of hiding it.
+- Nothing reaches the graph's main branch without a human signature.

--- a/services/agent-api/workspace-seed/templates/company._template.md
+++ b/services/agent-api/workspace-seed/templates/company._template.md
@@ -1,0 +1,18 @@
+# <Company Name>
+
+- industry: <industry>
+- relationship: <customer | prospect | partner | vendor | other>
+- first-seen: <YYYY-MM-DD>
+
+## Profile
+
+<Stable facts about this company — what it does, why it matters to the org.>
+
+## People
+
+- [[<Person>]] — <role>
+
+## Routine updates
+
+<!-- routine-updates:begin -->
+<!-- routine-updates:end -->

--- a/services/agent-api/workspace-seed/templates/meeting._template.md
+++ b/services/agent-api/workspace-seed/templates/meeting._template.md
@@ -1,0 +1,22 @@
+# Meeting: <title> (<YYYY-MM-DD>)
+
+- id: <meeting-id>
+- platform: <platform>
+- participants: [[<Person>]], [[<Person>]]
+- companies: [[<Company>]]
+
+## Summary
+
+<2–6 sentence narrative of what the meeting was about and what changed.>
+
+## Decisions
+
+- <decision> (owner: [[<Person>]])
+
+## Action items
+
+- [ ] <action> — [[<Person>]], due <YYYY-MM-DD or n/a>
+
+## Notable quotes / context
+
+- <optional supporting context>

--- a/services/agent-api/workspace-seed/templates/person._template.md
+++ b/services/agent-api/workspace-seed/templates/person._template.md
@@ -1,0 +1,15 @@
+# <Full Name>
+
+- role: <title / what they do>
+- company: [[<Company>]]
+- first-seen: <YYYY-MM-DD>
+
+## Profile
+
+<Stable facts about this person — who they are, what they own, how they decide.
+Changes here are deliberate restructurings, not routine appends.>
+
+## Routine updates
+
+<!-- routine-updates:begin -->
+<!-- routine-updates:end -->

--- a/services/vexa-agent/Dockerfile
+++ b/services/vexa-agent/Dockerfile
@@ -13,8 +13,10 @@ RUN chmod +x /system/bin/vexa
 
 ENV PATH="/system/bin:$PATH"
 
-# Workspace templates (copied into /workspace on first init)
-COPY features/knowledge-workspace/templates/knowledge/ /templates/knowledge/
+# Workspace templates (copied into /workspace on first init).
+# ei-lineage (#24): the old features/knowledge-workspace source was removed from
+# the tree; the committed org workspace seed is the single template source now.
+COPY services/agent-api/workspace-seed/ /templates/knowledge/
 
 # Git config for auto-commits
 RUN git config --global user.email "vexa@agent" && \

--- a/tests3/test-registry.yaml
+++ b/tests3/test-registry.yaml
@@ -49,6 +49,26 @@ tests:
     max_duration_sec: 120
 
   # ── Test scripts — retrofitted with step_* in Phase A ───────────
+  # ei-lineage (#24): meeting.completed → agent proposal → human-signed merge.
+  # Compose-only: agent-api + runtime-api org agent containers are a compose
+  # profile concern (lite/helm packaging is a follow-on pack). Deterministic —
+  # the agent step uses a per-org deterministic command through the full real
+  # lineage (no LLM credentials needed at this tier).
+  ei-lineage:
+    tier: cheap
+    runs_in: [compose]
+    script: tests/ei-lineage.sh
+    features: [enterprise-intelligence]
+    max_duration_sec: 900
+    steps:
+      - hook_wired         # POST_MEETING_HOOKS targets agent-api's consumer
+      - e2e_propose        # synthetic completed meeting → conforming proposal branch
+      - idempotent         # duplicate deliveries → exactly one proposal (proves #3)
+      - sign_gate          # main moves only via /sign; reject closes branch (proves #2)
+      - crash_safe         # induced failure → no partial branch; clean retry (proves #4)
+      - tenant_isolated    # two orgs → two workspaces; cross-org 404 (proves #5)
+      - flag_off_inert     # org flag default OFF → fully inert (proves #6)
+
   webhooks:
     tier: cheap
     runs_in: [lite, compose, helm]

--- a/tests3/tests/ei-lineage.sh
+++ b/tests3/tests/ei-lineage.sh
@@ -1,0 +1,320 @@
+#!/usr/bin/env bash
+# ei-lineage (#24): meeting.completed → agent proposal branch → human-signed merge.
+#
+# Step IDs (stable — the proves[] of pack ei-lineage, issue #24):
+#   hook_wired       — meeting-api's POST_MEETING_HOOKS points at agent-api's consumer
+#   e2e_propose      — seeded workspace + synthetic completed meeting → proposal branch
+#                      with schema-conforming meeting artifact + ≥1 entity update
+#   idempotent       — duplicate meeting.completed deliveries → exactly one proposal
+#   sign_gate        — main never changes without /sign; sign merges exactly the
+#                      proposal (409 on re-sign); reject closes the branch with a note
+#   crash_safe       — induced agent failure → no partial branch, visible failed
+#                      status, retry produces one clean proposal
+#   tenant_isolated  — two orgs land in two workspaces; cross-org reads are 404
+#   flag_off_inert   — org flag off (default) → no claim, no run, no workspace
+#
+# The agent step is driven through the FULL real lineage (runtime-api org
+# container, workspace clone transfer, exec, branch publication) with a
+# deterministic agent command injected per-org via the admin-controlled
+# user.data.ei.agent_cli seam — the same seam customer-local CLIs (Vibe/
+# OpenCode, epic #21) use. No LLM credentials are required, so this stays a
+# cheap-tier deterministic regression; the real-provider run is the P8 eyeball.
+#
+# Reads: .state/admin_url, .state/admin_token
+# Writes: .state/reports/<mode>/ei-lineage.json
+source "$(dirname "$0")/../lib/common.sh"
+
+ADMIN_URL=$(state_read admin_url)
+ADMIN_TOKEN=$(state_read admin_token)
+[ -z "$ADMIN_TOKEN" ] && ADMIN_TOKEN=$(grep -E '^ADMIN_TOKEN=' "$ROOT/.env" 2>/dev/null | cut -d= -f2)
+ADMIN_TOKEN=${ADMIN_TOKEN:-changeme}
+
+# agent-api binds 127.0.0.1:${AGENT_API_PORT:-8100} in compose.
+if [ -z "${AGENT_API_URL:-}" ]; then
+    AGENT_PORT=$(grep -E '^AGENT_API_PORT=' "$ROOT/.env" 2>/dev/null | cut -d= -f2)
+    AGENT_API_URL="http://localhost:${AGENT_PORT:-8100}"
+fi
+# agent-api API_KEY = BOT_API_TOKEN (may be empty = auth disabled in dev).
+EI_API_KEY=$(grep -E '^BOT_API_TOKEN=' "$ROOT/.env" 2>/dev/null | cut -d= -f2 || true)
+
+echo ""
+echo "  ei-lineage"
+echo "  ──────────────────────────────────────────────"
+
+test_begin ei-lineage
+
+EPOCH=$(date +%s)
+ORGA="eitest-a-$EPOCH"
+ORGB="eitest-b-$EPOCH"
+MA1="9${EPOCH}01"; MA2="9${EPOCH}02"; MA3="9${EPOCH}03"
+MB1="9${EPOCH}04"; MC1="9${EPOCH}05"
+
+# Deterministic writer "agent": creates the meeting artifact from the template
+# conventions + appends a dated confidence-scored entry inside the entity's
+# routine-updates region. Runs inside the real org agent container.
+WRITER='bash -ec "
+F=graph/kg/entities/meetings/\${EI_MEETING_ID}-sync.md
+mkdir -p graph/kg/entities/meetings graph/kg/entities/people
+{
+  echo \"# Meeting: Synthetic sync (\${EI_MEETING_ID})\"
+  echo
+  echo \"- id: \${EI_MEETING_ID}\"
+  echo \"- platform: google_meet\"
+  echo \"- participants: [[Jane Doe]]\"
+  echo \"- companies: [[Acme Corp]]\"
+  echo
+  echo \"## Summary\"
+  echo
+  echo \"Synthetic meeting artifact written by the deterministic regression agent.\"
+  echo
+  echo \"## Decisions\"
+  echo
+  echo \"- [[Jane Doe]] to follow up (owner: [[Jane Doe]])\"
+  echo
+  echo \"## Action items\"
+  echo
+  echo \"- [ ] follow up — [[Jane Doe]], due n/a\"
+} > \$F
+sed -i \"s|<!-- routine-updates:end -->|- \$(date -u +%F) [conf:0.9] Discussed in meeting \${EI_MEETING_ID} (source: [[Meeting \${EI_MEETING_ID}]])\n<!-- routine-updates:end -->|\" graph/kg/entities/people/jane-doe.md
+"'
+CRASHER='bash -ec "exit 7"'
+
+api_curl() {  # api_curl <curl args...> — adds X-API-Key when configured
+    if [ -n "$EI_API_KEY" ]; then
+        curl -s -H "X-API-Key: $EI_API_KEY" "$@"
+    else
+        curl -s "$@"
+    fi
+}
+
+create_user() {  # create_user <email> → user id
+    curl -s -X POST "$ADMIN_URL/admin/users" \
+        -H "X-Admin-API-Key: $ADMIN_TOKEN" -H "Content-Type: application/json" \
+        -d "{\"email\":\"$1\",\"name\":\"EI Test\"}" \
+        | python3 -c "import sys,json; print(json.load(sys.stdin).get('id',''))"
+}
+
+set_ei() {  # set_ei <user_id> <org_id> <agent_cli ('' = remove override)>
+    python3 - "$1" "$2" "$3" <<'PY' > /tmp/.ei-patch.json
+import json, sys
+uid, org, cli = sys.argv[1], sys.argv[2], sys.argv[3]
+ei = {"enabled": True, "org_id": org}
+if cli:
+    ei["agent_cli"] = cli
+print(json.dumps({"data": {"ei": ei}}))
+PY
+    local code
+    code=$(curl -s -o /dev/null -w '%{http_code}' -X PATCH "$ADMIN_URL/admin/users/$1" \
+        -H "X-Admin-API-Key: $ADMIN_TOKEN" -H "Content-Type: application/json" \
+        -d @/tmp/.ei-patch.json)
+    [ "$code" = "200" ]
+}
+
+deliver() {  # deliver <user_id> <meeting_id> [event_suffix] → response body
+    curl -s -X POST "$AGENT_API_URL/internal/webhooks/meeting-completed" \
+        -H "Content-Type: application/json" \
+        -d "{\"event_id\":\"evt_eitest_$2${3:-}\",\"event_type\":\"meeting.completed\",\"api_version\":\"2026-03-01\",\"created_at\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"data\":{\"meeting\":{\"id\":$2,\"user_id\":$1,\"platform\":\"google_meet\",\"status\":\"completed\",\"title\":\"EI synthetic meeting $2\"}}}"
+}
+
+run_status() {  # run_status <org> <meeting> → claim status string ('' if none)
+    curl -s "$AGENT_API_URL/internal/ei/status?org_id=$1&meeting_id=$2" \
+        | python3 -c "import sys,json; c=json.load(sys.stdin).get('claim'); print(c.get('status','') if c else '')" 2>/dev/null
+}
+
+wait_status() {  # wait_status <org> <meeting> <want> <timeout_s>
+    local i=0 st=""
+    while [ $i -lt "$4" ]; do
+        st=$(run_status "$1" "$2")
+        [ "$st" = "$3" ] && return 0
+        # fail fast when waiting for success but the run already failed
+        if [ "$3" = "proposed" ] && [ "$st" = "failed" ]; then return 1; fi
+        sleep 3; i=$((i+3))
+    done
+    return 1
+}
+
+ws_git() {  # ws_git <org> <git args...>
+    local org="$1"; shift
+    svc_exec agent-api git -C "/workspaces/$org/repo" "$@"
+}
+
+proposals_for() {  # proposals_for <org> <meeting_id> → count
+    api_curl "$AGENT_API_URL/api/proposals?org=$1" | python3 -c "
+import sys,json
+mid=int('$2')
+print(sum(1 for p in json.load(sys.stdin) if p.get('meeting_id')==mid))" 2>/dev/null
+}
+
+proposal_id_for() {  # proposal_id_for <org> <meeting_id>
+    api_curl "$AGENT_API_URL/api/proposals?org=$1" | python3 -c "
+import sys,json
+mid=int('$2')
+for p in json.load(sys.stdin):
+    if p.get('meeting_id')==mid: print(p['id']); break" 2>/dev/null
+}
+
+# ── Setup (not steps): agent-api up + three users ─────────────────
+if ! curl -sf "$AGENT_API_URL/health" > /dev/null 2>&1; then
+    step_fail hook_wired "agent-api not reachable at $AGENT_API_URL"
+    exit 1
+fi
+UA=$(create_user "ei-a-$EPOCH@test.vexa.ai")
+UB=$(create_user "ei-b-$EPOCH@test.vexa.ai")
+UC=$(create_user "ei-c-$EPOCH@test.vexa.ai")
+if [ -z "$UA" ] || [ -z "$UB" ] || [ -z "$UC" ]; then
+    step_fail hook_wired "could not create test users via $ADMIN_URL"
+    exit 1
+fi
+set_ei "$UA" "$ORGA" "$WRITER" || { step_fail hook_wired "PATCH ei config failed for user $UA"; exit 1; }
+set_ei "$UB" "$ORGB" "$WRITER" || { step_fail hook_wired "PATCH ei config failed for user $UB"; exit 1; }
+info "users: A=$UA ($ORGA) B=$UB ($ORGB) C=$UC (flag off)"
+
+# ── Step: hook_wired ───────────────────────────────────────────────
+HOOKS=$(svc_exec meeting-api sh -c 'echo $POST_MEETING_HOOKS' 2>/dev/null || echo "")
+if echo "$HOOKS" | grep -q "agent-api.*meeting-completed"; then
+    step_pass hook_wired "POST_MEETING_HOOKS → agent-api consumer ($HOOKS)"
+else
+    step_fail hook_wired "POST_MEETING_HOOKS does not target agent-api: '$HOOKS'"
+fi
+
+# ── Step: e2e_propose ─────────────────────────────────────────────
+R=$(deliver "$UA" "$MA1")
+ST=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('status',''))" 2>/dev/null)
+if [ "$ST" != "accepted" ]; then
+    step_fail e2e_propose "delivery not accepted: $R"
+    exit 1
+fi
+if ! wait_status "$ORGA" "$MA1" proposed 180; then
+    step_fail e2e_propose "run did not reach 'proposed' (last status: $(run_status "$ORGA" "$MA1"))"
+    exit 1
+fi
+PID1=$(proposal_id_for "$ORGA" "$MA1")
+BR_OK=$(ws_git "$ORGA" rev-parse --verify "refs/heads/meeting/$MA1" 2>/dev/null || echo "")
+DIFF=$(api_curl "$AGENT_API_URL/api/proposals/$PID1/diff?org=$ORGA")
+E2E_VERDICT=$(echo "$DIFF" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+files = d.get('files', [])
+meeting = [f for f in files if f['path'].startswith('graph/kg/entities/meetings/') and f['status'] == 'added']
+entity = [f for f in files if f['path'] == 'graph/kg/entities/people/jane-doe.md' and f['status'] == 'modified']
+schema = meeting and all(s in meeting[0]['after'] for s in ('## Summary', '## Decisions', '## Action items', '[[Jane Doe]]'))
+appended = entity and '[conf:0.9] Discussed in meeting $MA1' in entity[0]['after']
+print('ok' if (meeting and entity and schema and appended) else f'bad: meeting={len(meeting)} entity={len(entity)} schema={bool(schema)} appended={bool(appended)}')" 2>/dev/null)
+if [ -n "$PID1" ] && [ -n "$BR_OK" ] && [ "$E2E_VERDICT" = "ok" ]; then
+    step_pass e2e_propose "proposal $PID1 on meeting/$MA1: conforming artifact + entity update"
+else
+    step_fail e2e_propose "pid=$PID1 branch=$BR_OK diff=$E2E_VERDICT"
+fi
+
+# ── Step: idempotent ──────────────────────────────────────────────
+R2=$(deliver "$UA" "$MA1" "-dup")
+ST2=$(echo "$R2" | python3 -c "import sys,json; print(json.load(sys.stdin).get('status',''))" 2>/dev/null)
+N1=$(proposals_for "$ORGA" "$MA1")
+if [ "$ST2" = "duplicate" ] && [ "$N1" = "1" ]; then
+    step_pass idempotent "duplicate delivery → '$ST2', still exactly 1 proposal"
+else
+    step_fail idempotent "redelivery status='$ST2', proposals for $MA1: $N1"
+fi
+
+# ── Step: sign_gate ───────────────────────────────────────────────
+SIGN_OK=1
+MAIN0=$(ws_git "$ORGA" rev-parse main)
+SEED0=$(ws_git "$ORGA" rev-list --max-parents=0 main | head -1)
+if [ "$MAIN0" != "$SEED0" ]; then
+    SIGN_OK=0; info "main moved without sign: $MAIN0 != seed $SEED0"
+fi
+SIGN_RESP=$(api_curl -X POST "$AGENT_API_URL/api/proposals/$PID1/sign?org=$ORGA")
+MERGED=$(echo "$SIGN_RESP" | python3 -c "import sys,json; d=json.load(sys.stdin); print('yes' if d.get('merged') and d.get('merge_commit') else 'no')" 2>/dev/null)
+MAIN1=$(ws_git "$ORGA" rev-parse main)
+MC=$(echo "$SIGN_RESP" | python3 -c "import sys,json; print(json.load(sys.stdin).get('merge_commit',''))" 2>/dev/null)
+ARTIFACT_ON_MAIN=$(ws_git "$ORGA" ls-tree -r --name-only main | grep -c "graph/kg/entities/meetings/$MA1" || true)
+[ "$MERGED" = "yes" ] && [ "$MAIN1" = "$MC" ] && [ "$ARTIFACT_ON_MAIN" -ge 1 ] || { SIGN_OK=0; info "sign: merged=$MERGED main=$MAIN1 mc=$MC artifact=$ARTIFACT_ON_MAIN resp=$SIGN_RESP"; }
+RESIGN_CODE=$(api_curl -o /dev/null -w '%{http_code}' -X POST "$AGENT_API_URL/api/proposals/$PID1/sign?org=$ORGA")
+[ "$RESIGN_CODE" = "409" ] || { SIGN_OK=0; info "re-sign returned $RESIGN_CODE (want 409)"; }
+
+# reject path on a second proposal
+deliver "$UA" "$MA2" > /dev/null
+if wait_status "$ORGA" "$MA2" proposed 180; then
+    PID2=$(proposal_id_for "$ORGA" "$MA2")
+    MAIN2=$(ws_git "$ORGA" rev-parse main)
+    NONOTE_CODE=$(api_curl -o /dev/null -w '%{http_code}' -X POST "$AGENT_API_URL/api/proposals/$PID2/reject?org=$ORGA" -H "Content-Type: application/json" -d '{}')
+    case "$NONOTE_CODE" in 400|422) : ;; *) SIGN_OK=0; info "reject without note returned $NONOTE_CODE (want 400/422)";; esac
+    REJ=$(api_curl -X POST "$AGENT_API_URL/api/proposals/$PID2/reject?org=$ORGA" -H "Content-Type: application/json" -d '{"note":"synthetic regression reject"}')
+    CLOSED=$(echo "$REJ" | python3 -c "import sys,json; print('yes' if json.load(sys.stdin).get('closed') else 'no')" 2>/dev/null)
+    BR2=$(ws_git "$ORGA" rev-parse --verify "refs/heads/meeting/$MA2" 2>/dev/null || echo "")
+    MAIN3=$(ws_git "$ORGA" rev-parse main)
+    SIGN_AFTER_REJECT=$(api_curl -o /dev/null -w '%{http_code}' -X POST "$AGENT_API_URL/api/proposals/$PID2/sign?org=$ORGA")
+    if [ "$CLOSED" != "yes" ] || [ -n "$BR2" ] || [ "$MAIN3" != "$MAIN2" ] || [ "$SIGN_AFTER_REJECT" != "409" ]; then
+        SIGN_OK=0; info "reject: closed=$CLOSED branch='$BR2' main $MAIN2→$MAIN3 sign-after=$SIGN_AFTER_REJECT"
+    fi
+else
+    SIGN_OK=0; info "second proposal ($MA2) never reached proposed"
+fi
+if [ "$SIGN_OK" = "1" ]; then
+    step_pass sign_gate "main moves only via /sign; re-sign 409; reject closes branch with note"
+else
+    step_fail sign_gate "see info lines above"
+fi
+
+# ── Step: crash_safe ──────────────────────────────────────────────
+CRASH_OK=1
+set_ei "$UA" "$ORGA" "$CRASHER" || CRASH_OK=0
+deliver "$UA" "$MA3" > /dev/null
+if wait_status "$ORGA" "$MA3" failed 120; then
+    BR3=$(ws_git "$ORGA" rev-parse --verify "refs/heads/meeting/$MA3" 2>/dev/null || echo "")
+    [ -z "$BR3" ] || { CRASH_OK=0; info "partial branch meeting/$MA3 exists after crash"; }
+else
+    CRASH_OK=0; info "crash run never reached visible 'failed' status"
+fi
+# retry after fixing the agent → exactly one clean proposal
+set_ei "$UA" "$ORGA" "$WRITER" || CRASH_OK=0
+R3=$(deliver "$UA" "$MA3" "-retry")
+ST3=$(echo "$R3" | python3 -c "import sys,json; print(json.load(sys.stdin).get('status',''))" 2>/dev/null)
+[ "$ST3" = "accepted" ] || { CRASH_OK=0; info "retry delivery not re-claimed: $R3"; }
+if wait_status "$ORGA" "$MA3" proposed 180; then
+    N3=$(proposals_for "$ORGA" "$MA3")
+    BR3=$(ws_git "$ORGA" rev-parse --verify "refs/heads/meeting/$MA3" 2>/dev/null || echo "")
+    [ "$N3" = "1" ] && [ -n "$BR3" ] || { CRASH_OK=0; info "retry: proposals=$N3 branch='$BR3'"; }
+else
+    CRASH_OK=0; info "retry run never proposed (status: $(run_status "$ORGA" "$MA3"))"
+fi
+if [ "$CRASH_OK" = "1" ]; then
+    step_pass crash_safe "crash → failed status, no branch; retry → one clean proposal"
+else
+    step_fail crash_safe "see info lines above"
+fi
+
+# ── Step: tenant_isolated ─────────────────────────────────────────
+ISO_OK=1
+deliver "$UB" "$MB1" > /dev/null
+if wait_status "$ORGB" "$MB1" proposed 180; then
+    PIDB=$(proposal_id_for "$ORGB" "$MB1")
+    NB_IN_A=$(proposals_for "$ORGA" "$MB1")
+    CROSS_CODE=$(api_curl -o /dev/null -w '%{http_code}' "$AGENT_API_URL/api/proposals/$PIDB/diff?org=$ORGA")
+    BR_B_IN_A=$(ws_git "$ORGA" rev-parse --verify "refs/heads/meeting/$MB1" 2>/dev/null || echo "")
+    WS_B=$(svc_exec agent-api test -d "/workspaces/$ORGB/repo/.git" && echo yes || echo no)
+    if [ "$NB_IN_A" != "0" ] || [ "$CROSS_CODE" != "404" ] || [ -n "$BR_B_IN_A" ] || [ "$WS_B" != "yes" ]; then
+        ISO_OK=0; info "isolation: B-in-A=$NB_IN_A cross-org-diff=$CROSS_CODE branch-in-A='$BR_B_IN_A' wsB=$WS_B"
+    fi
+else
+    ISO_OK=0; info "org B run never proposed (status: $(run_status "$ORGB" "$MB1"))"
+fi
+if [ "$ISO_OK" = "1" ]; then
+    step_pass tenant_isolated "two orgs → two workspaces; cross-org reads are 404"
+else
+    step_fail tenant_isolated "see info lines above"
+fi
+
+# ── Step: flag_off_inert ──────────────────────────────────────────
+RC=$(deliver "$UC" "$MC1")
+STC=$(echo "$RC" | python3 -c "import sys,json; print(json.load(sys.stdin).get('status',''))" 2>/dev/null)
+sleep 2
+CLAIM_C=$(run_status "user-$UC" "$MC1")
+WS_C=$(svc_exec agent-api test -d "/workspaces/user-$UC" && echo yes || echo no)
+if [ "$STC" = "inert" ] && [ -z "$CLAIM_C" ] && [ "$WS_C" = "no" ]; then
+    step_pass flag_off_inert "flag off (default) → '$STC', no claim, no workspace"
+else
+    step_fail flag_off_inert "status='$STC' claim='$CLAIM_C' workspace=$WS_C"
+fi
+
+test_end

--- a/tests3/tests/ei-lineage.sh
+++ b/tests3/tests/ei-lineage.sh
@@ -25,13 +25,15 @@
 source "$(dirname "$0")/../lib/common.sh"
 
 ADMIN_URL=$(state_read admin_url)
-ADMIN_TOKEN=$(state_read admin_token)
-[ -z "$ADMIN_TOKEN" ] && ADMIN_TOKEN=$(grep -E '^ADMIN_TOKEN=' "$ROOT/.env" 2>/dev/null | cut -d= -f2)
+ADMIN_TOKEN=$(state_read admin_token 2>/dev/null || true)
+if [ -z "$ADMIN_TOKEN" ]; then
+    ADMIN_TOKEN=$(grep -E '^ADMIN_TOKEN=' "$ROOT/.env" 2>/dev/null | cut -d= -f2 || true)
+fi
 ADMIN_TOKEN=${ADMIN_TOKEN:-changeme}
 
 # agent-api binds 127.0.0.1:${AGENT_API_PORT:-8100} in compose.
 if [ -z "${AGENT_API_URL:-}" ]; then
-    AGENT_PORT=$(grep -E '^AGENT_API_PORT=' "$ROOT/.env" 2>/dev/null | cut -d= -f2)
+    AGENT_PORT=$(grep -E '^AGENT_API_PORT=' "$ROOT/.env" 2>/dev/null | cut -d= -f2 || true)
     AGENT_API_URL="http://localhost:${AGENT_PORT:-8100}"
 fi
 # agent-api API_KEY = BOT_API_TOKEN (may be empty = auth disabled in dev).
@@ -91,7 +93,7 @@ create_user() {  # create_user <email> → user id
     curl -s -X POST "$ADMIN_URL/admin/users" \
         -H "X-Admin-API-Key: $ADMIN_TOKEN" -H "Content-Type: application/json" \
         -d "{\"email\":\"$1\",\"name\":\"EI Test\"}" \
-        | python3 -c "import sys,json; print(json.load(sys.stdin).get('id',''))"
+        | python3 -c "import sys,json; print(json.load(sys.stdin).get('id',''))" 2>/dev/null || true
 }
 
 set_ei() {  # set_ei <user_id> <org_id> <agent_cli ('' = remove override)>
@@ -118,7 +120,7 @@ deliver() {  # deliver <user_id> <meeting_id> [event_suffix] → response body
 
 run_status() {  # run_status <org> <meeting> → claim status string ('' if none)
     curl -s "$AGENT_API_URL/internal/ei/status?org_id=$1&meeting_id=$2" \
-        | python3 -c "import sys,json; c=json.load(sys.stdin).get('claim'); print(c.get('status','') if c else '')" 2>/dev/null
+        | python3 -c "import sys,json; c=json.load(sys.stdin).get('claim'); print(c.get('status','') if c else '')" 2>/dev/null || true
 }
 
 wait_status() {  # wait_status <org> <meeting> <want> <timeout_s>
@@ -142,7 +144,7 @@ proposals_for() {  # proposals_for <org> <meeting_id> → count
     api_curl "$AGENT_API_URL/api/proposals?org=$1" | python3 -c "
 import sys,json
 mid=int('$2')
-print(sum(1 for p in json.load(sys.stdin) if p.get('meeting_id')==mid))" 2>/dev/null
+print(sum(1 for p in json.load(sys.stdin) if p.get('meeting_id')==mid))" 2>/dev/null || echo -1
 }
 
 proposal_id_for() {  # proposal_id_for <org> <meeting_id>
@@ -150,7 +152,7 @@ proposal_id_for() {  # proposal_id_for <org> <meeting_id>
 import sys,json
 mid=int('$2')
 for p in json.load(sys.stdin):
-    if p.get('meeting_id')==mid: print(p['id']); break" 2>/dev/null
+    if p.get('meeting_id')==mid: print(p['id']); break" 2>/dev/null || true
 }
 
 # ── Setup (not steps): agent-api up + three users ─────────────────
@@ -179,7 +181,7 @@ fi
 
 # ── Step: e2e_propose ─────────────────────────────────────────────
 R=$(deliver "$UA" "$MA1")
-ST=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('status',''))" 2>/dev/null)
+ST=$(echo "$R" | python3 -c "import sys,json; print(json.load(sys.stdin).get('status',''))" 2>/dev/null || true)
 if [ "$ST" != "accepted" ]; then
     step_fail e2e_propose "delivery not accepted: $R"
     exit 1
@@ -199,7 +201,7 @@ meeting = [f for f in files if f['path'].startswith('graph/kg/entities/meetings/
 entity = [f for f in files if f['path'] == 'graph/kg/entities/people/jane-doe.md' and f['status'] == 'modified']
 schema = meeting and all(s in meeting[0]['after'] for s in ('## Summary', '## Decisions', '## Action items', '[[Jane Doe]]'))
 appended = entity and '[conf:0.9] Discussed in meeting $MA1' in entity[0]['after']
-print('ok' if (meeting and entity and schema and appended) else f'bad: meeting={len(meeting)} entity={len(entity)} schema={bool(schema)} appended={bool(appended)}')" 2>/dev/null)
+print('ok' if (meeting and entity and schema and appended) else f'bad: meeting={len(meeting)} entity={len(entity)} schema={bool(schema)} appended={bool(appended)}')" 2>/dev/null || echo parse-error)
 if [ -n "$PID1" ] && [ -n "$BR_OK" ] && [ "$E2E_VERDICT" = "ok" ]; then
     step_pass e2e_propose "proposal $PID1 on meeting/$MA1: conforming artifact + entity update"
 else
@@ -208,7 +210,7 @@ fi
 
 # ── Step: idempotent ──────────────────────────────────────────────
 R2=$(deliver "$UA" "$MA1" "-dup")
-ST2=$(echo "$R2" | python3 -c "import sys,json; print(json.load(sys.stdin).get('status',''))" 2>/dev/null)
+ST2=$(echo "$R2" | python3 -c "import sys,json; print(json.load(sys.stdin).get('status',''))" 2>/dev/null || true)
 N1=$(proposals_for "$ORGA" "$MA1")
 if [ "$ST2" = "duplicate" ] && [ "$N1" = "1" ]; then
     step_pass idempotent "duplicate delivery → '$ST2', still exactly 1 proposal"
@@ -224,9 +226,9 @@ if [ "$MAIN0" != "$SEED0" ]; then
     SIGN_OK=0; info "main moved without sign: $MAIN0 != seed $SEED0"
 fi
 SIGN_RESP=$(api_curl -X POST "$AGENT_API_URL/api/proposals/$PID1/sign?org=$ORGA")
-MERGED=$(echo "$SIGN_RESP" | python3 -c "import sys,json; d=json.load(sys.stdin); print('yes' if d.get('merged') and d.get('merge_commit') else 'no')" 2>/dev/null)
+MERGED=$(echo "$SIGN_RESP" | python3 -c "import sys,json; d=json.load(sys.stdin); print('yes' if d.get('merged') and d.get('merge_commit') else 'no')" 2>/dev/null || echo no)
 MAIN1=$(ws_git "$ORGA" rev-parse main)
-MC=$(echo "$SIGN_RESP" | python3 -c "import sys,json; print(json.load(sys.stdin).get('merge_commit',''))" 2>/dev/null)
+MC=$(echo "$SIGN_RESP" | python3 -c "import sys,json; print(json.load(sys.stdin).get('merge_commit',''))" 2>/dev/null || true)
 ARTIFACT_ON_MAIN=$(ws_git "$ORGA" ls-tree -r --name-only main | grep -c "graph/kg/entities/meetings/$MA1" || true)
 [ "$MERGED" = "yes" ] && [ "$MAIN1" = "$MC" ] && [ "$ARTIFACT_ON_MAIN" -ge 1 ] || { SIGN_OK=0; info "sign: merged=$MERGED main=$MAIN1 mc=$MC artifact=$ARTIFACT_ON_MAIN resp=$SIGN_RESP"; }
 RESIGN_CODE=$(api_curl -o /dev/null -w '%{http_code}' -X POST "$AGENT_API_URL/api/proposals/$PID1/sign?org=$ORGA")
@@ -240,7 +242,7 @@ if wait_status "$ORGA" "$MA2" proposed 180; then
     NONOTE_CODE=$(api_curl -o /dev/null -w '%{http_code}' -X POST "$AGENT_API_URL/api/proposals/$PID2/reject?org=$ORGA" -H "Content-Type: application/json" -d '{}')
     case "$NONOTE_CODE" in 400|422) : ;; *) SIGN_OK=0; info "reject without note returned $NONOTE_CODE (want 400/422)";; esac
     REJ=$(api_curl -X POST "$AGENT_API_URL/api/proposals/$PID2/reject?org=$ORGA" -H "Content-Type: application/json" -d '{"note":"synthetic regression reject"}')
-    CLOSED=$(echo "$REJ" | python3 -c "import sys,json; print('yes' if json.load(sys.stdin).get('closed') else 'no')" 2>/dev/null)
+    CLOSED=$(echo "$REJ" | python3 -c "import sys,json; print('yes' if json.load(sys.stdin).get('closed') else 'no')" 2>/dev/null || echo no)
     BR2=$(ws_git "$ORGA" rev-parse --verify "refs/heads/meeting/$MA2" 2>/dev/null || echo "")
     MAIN3=$(ws_git "$ORGA" rev-parse main)
     SIGN_AFTER_REJECT=$(api_curl -o /dev/null -w '%{http_code}' -X POST "$AGENT_API_URL/api/proposals/$PID2/sign?org=$ORGA")
@@ -269,7 +271,7 @@ fi
 # retry after fixing the agent → exactly one clean proposal
 set_ei "$UA" "$ORGA" "$WRITER" || CRASH_OK=0
 R3=$(deliver "$UA" "$MA3" "-retry")
-ST3=$(echo "$R3" | python3 -c "import sys,json; print(json.load(sys.stdin).get('status',''))" 2>/dev/null)
+ST3=$(echo "$R3" | python3 -c "import sys,json; print(json.load(sys.stdin).get('status',''))" 2>/dev/null || true)
 [ "$ST3" = "accepted" ] || { CRASH_OK=0; info "retry delivery not re-claimed: $R3"; }
 if wait_status "$ORGA" "$MA3" proposed 180; then
     N3=$(proposals_for "$ORGA" "$MA3")
@@ -307,7 +309,7 @@ fi
 
 # ── Step: flag_off_inert ──────────────────────────────────────────
 RC=$(deliver "$UC" "$MC1")
-STC=$(echo "$RC" | python3 -c "import sys,json; print(json.load(sys.stdin).get('status',''))" 2>/dev/null)
+STC=$(echo "$RC" | python3 -c "import sys,json; print(json.load(sys.stdin).get('status',''))" 2>/dev/null || true)
 sleep 2
 CLAIM_C=$(run_status "user-$UC" "$MC1")
 WS_C=$(svc_exec agent-api test -d "/workspaces/user-$UC" && echo yes || echo no)


### PR DESCRIPTION
## [Pack ei-lineage] meeting.completed → agent proposes entity-graph diff → human-signed merge

Closes #24 (epic #21 `enterprise-intelligence`). Companion pack #25 (`ei-review-ui`) builds against the frozen contract below.

### The lineage (one vertical slice)

`meeting.completed` envelope (consumed from meeting-api's hardened **POST_MEETING_HOOKS** seam — delivery machinery untouched, agent-api only consumes)
→ resolve user → **org EI config** (`user.data.ei`, org-level enable flag **default OFF**)
→ **atomic per-meeting claim** in Redis (claim-before-run; duplicate-delivery-safe — the #330 receiving-side lesson; failed runs release the claim for safe retry)
→ ensure the **org's seeded knowledge git repo** (one per org, on the `agent-workspaces` volume)
→ ensure the **org's agent container** (runtime-api `agent` profile, one container per org)
→ agent runs on an **isolated working clone** + transcript (fetched from the collector's internal endpoint)
→ **proposal branch `meeting/<meeting-id>`** lands in the org repo in a single atomic fetch, only after a successful, schema-conforming run
→ **sign API**: nothing reaches workspace `main` except `/sign`.

New module: `services/agent-api/agent_api/lineage.py`. Consumer endpoint: the existing `/internal/webhooks/meeting-completed` stub now dispatches to the pipeline (responds fast; the run is a background task).

### Frozen sign-API contract v1 (P2-signed on #24 — #25 develops against THIS; changes require a new P2 note)

```
GET  /api/proposals?org=<org_id>            -> 200 [{id, meeting_id, meeting_title, created_at, branch, summary, files_changed}]
GET  /api/proposals/{id}/diff               -> 200 {proposal_id, files: [{path, status: added|modified, before, after, patch}]}
POST /api/proposals/{id}/sign               -> 200 {merged: true, merge_commit}     (idempotent; 409 if already merged/rejected)
POST /api/proposals/{id}/reject {note}      -> 200 {closed: true}                   (note required -> 422 without it)
```

Auth: `X-API-Key` (agent-api's existing seam; the dashboard session fronts it in #25). All routes org-scoped — cross-org access is a **404**, never a 403. Git-native review stays the engineer fallback (`git -C /workspaces/<org>/repo log/diff` inside agent-api).

### Workspace = seeded git repo per org

Seed committed at `services/agent-api/workspace-seed/` (**synthetic content only**), baked into the agent-api image, copied + `git init` on an org's first event:

- `graph/kg/entities/{people,companies,meetings}/` — wikilinked markdown entities with a single `routine-updates` region (dated, confidence-scored appends; single write path per region)
- `graph/sg/` — org doctrine/strategy nodes
- `templates/` — `meeting._template.md`, `person._template.md`, `company._template.md`
- `AGENT.md` — the agent's own instruction file **inside the workspace**: self-managed, versioned with the knowledge, per-org by construction.

### Provider note (env only — nothing hardcoded)

Agent invocation resolves: org `user.data.ei.agent_cli` → env `EI_AGENT_CMD` → built from `AGENT_CLI`/`AGENT_ALLOWED_TOOLS`/(`user.data.ei.model` or `DEFAULT_MODEL`). Org agent containers default to the in-repo `vexa-agent` image (`AGENT_IMAGE` env); per-org container env (e.g. `ANTHROPIC_BASE_URL` for the #22/PR #23 LiteLLM chain) injects via `user.data.ei.env`. The per-org `agent_cli` seam is the same admin-controlled trust level as the existing per-user container env injection, and is what lets Vibe/OpenCode-class CLIs ride the identical lineage.

### Safety rails

- **flag-off-inert:** org-level enable flag default OFF — on existing deployments the consumer answers `inert` and creates *zero* state (no claim, no workspace, no container, no token burn).
- **duplicate-delivery-safe:** atomic Redis claim (Lua: claim if absent or previously `failed`) before any run; re-delivery answers `duplicate`.
- **crash-safe:** the agent works on an isolated clone in a temp run dir; the proposal branch is published into the org repo only after a successful conforming commit — induced failure leaves **no partial branch**, a visible `failed` status (`GET /internal/ei/status?org_id&meeting_id`), and a re-claimable meeting.

### proves[] — every entry has a regression check (`tests3/tests/ei-lineage.sh`, compose tier, registered in `test-registry.yaml`)

| proves | step | live result |
|---|---|---|
| e2e-propose | `e2e_propose` | ✅ proposal branch with conforming meeting artifact + entity update |
| sign-gate | `sign_gate` | ✅ main is seed-sha until `/sign`; sign merges exactly the proposal (re-sign 409); reject closes branch, note required |
| idempotent | `idempotent` | ✅ duplicate delivery → `duplicate`, exactly one proposal |
| crash-safe | `crash_safe` | ✅ induced failure → `failed` status, no partial branch; retry → one clean proposal |
| tenant-isolated | `tenant_isolated` | ✅ two orgs → two workspaces; cross-org reads 404 |
| flag-off-inert | `flag_off_inert` | ✅ default-off user → `inert`, no claim, no workspace |
| (wiring) | `hook_wired` | ✅ POST_MEETING_HOOKS → agent-api consumer |

The regression drives the **full real lineage** (runtime-api org container, clone transfer, exec, atomic branch publication, sign/reject git mechanics) with a deterministic per-org agent command — no LLM credentials at the cheap tier, deterministic by design (same pattern as the synthetic transcription rig). The real-provider run is the P8 eyeball (`live-required: no` per the pack).

Unit tests: `services/agent-api/tests/test_lineage.py` (org sanitization incl. traversal, provider-resolution order, frozen contract shape, prompt invariants).

### Deploy changes

- **agent-api re-enabled in compose** (was NO-SHIP): healthcheck, `agent-workspaces` volume, EI env. Added to `IMAGES` (build/publish/promote).
- `POST_MEETING_HOOKS` default now targets the agent-api consumer (safe: flag-off-inert).
- `AGENT_IMAGE` defaults to `vexaai/vexa-agent:${IMAGE_TAG}` for runtime-api + agent-api; `vexa-agent` Dockerfile fixed (stale `features/` COPY — that tree no longer exists; the committed workspace seed is the single template source) and added to build/publish (`build-agent-image`).

### Validate (develop floor, engine-produced substrate)

- `make build` → artifact **`0.10.6.3-260610-2039`** built and published; `:dev` updated (all images incl. `agent-api`, `vexa-agent`).
- `make deploy MODE=compose ENV=local` → stack green on that exact tag (config faithfulness checked: running `agent-api` container is `vexaai/agent-api:0.10.6.3-260610-2039`, `POST_MEETING_HOOKS` and `AGENT_IMAGE` verified inside the live containers).
- Compose validate matrix (`make -C tests3 validate-compose` — the same command CI's rung-writer runs; the top-level `make validate MODE=compose` verb is wired to the throwaway-VM path, as PR #23 documented): **failure set compared against the clean base** (`origin/tests3-stateless` checkout run against the same live stack) — see the comparison below; **no new reds attributable to this pack**, and the new `ei-lineage` test is green in the matrix.
- Static floor: `docs` 4/4 green; `locks` 88/89 with the single red (`PACK_E1A_CONCURRENT_CHUNKS_REPRODUCER_PASSES`) reproduced **identically on the clean base** (pre-existing, also documented by PR #23).

**Failure-set comparison (branch vs clean base, same live stack, same env):**

- `missing reports:` lists — **byte-identical** (47 entries; pre-existing on this lineage: removed scripts / stale registry bindings, exactly the class PR #23 documented).
- `failed:` lists — identical 8 shared pre-existing reds: `advisory-dependency-floors`, `smoke-static` (the known `PACK_E1A_CONCURRENT_CHUNKS_REPRODUCER_PASSES` lock), `smoke-health` (probes default localhost ports 8090/9000 — this validation stack runs port-shifted to coexist with other local stacks; identical red on base), and 5 × `v0.10.6.1-tts-auto-lang-*`.
- Single branch-only delta: `dashboard-proxy` — failed only because the branch matrix was the **first run against the fresh stack** (0 meetings in DB yet); re-run on the branch tree after the stack had meetings: **green** (`meetings_list: 2 meetings`, `field_contract` pass, `bot_create_proxy` 201). Not attributable to this pack (the pack touches no dashboard/meeting-list surface).
- New `ei-lineage` test inside the branch matrix: **all 7 steps green** (report artifact `tests3/.state/reports/compose/ei-lineage.json`, `status: pass`).

### P8 note (`live-required: no`)

The real-meeting, real-provider e2e is the sprint/P8 eyeball: enable the flag for one org (`PATCH /admin/users/{id}` → `data.ei={enabled:true,org_id:…}`), run a live meeting, watch `meeting/<id>` appear, review and sign from any git UI or via the sign API (or #25's dashboard once it lands).

### Out of scope (per pack)

Dashboard review UI (#25) · recall/Qdrant indexing (`ei-recall`) · local-LLM provider wiring beyond env passthrough (#22/PR #23 own the proof) · S3 backing beyond a git repo on a volume · per-org seed customization tooling · lite/helm packaging of agent-api (compose profile only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
