### PR TITLE
Pack ei-review-ui: dashboard approve-button for agent knowledge proposals (#25)

### DIFF
--- a/services/dashboard/src/app/api/proposals/[[...path]]/route.ts
+++ b/services/dashboard/src/app/api/proposals/[[...path]]/route.ts
@@ -1,0 +1,96 @@
+/**
+ * Dashboard proxy for the EI sign API (frozen contract v1 — issue #25).
+ *
+ * Forwards to agent-api with the service token, but the org query param is
+ * ALWAYS resolved server-side from the authenticated dashboard session
+ * (src/lib/ei-org.ts) — any client-supplied `org` is discarded, which is what
+ * enforces the tenant-scoped prove: a user of org A can neither list nor act
+ * on org B proposals through this surface.
+ *
+ * Routes (mirroring the contract):
+ *   GET  /api/proposals               -> list pending proposals for MY org
+ *   GET  /api/proposals/{id}/diff     -> per-file diff
+ *   POST /api/proposals/{id}/sign     -> approve (merge)
+ *   POST /api/proposals/{id}/reject   -> reject with required note
+ */
+
+import { NextRequest } from "next/server";
+import { getAuthenticatedEiOrg } from "@/lib/ei-org";
+import { buildProposalsTarget, parseProposalsPath } from "@/lib/proposals";
+
+const AGENT_API_URL = process.env.AGENT_API_URL || "http://localhost:8100";
+// Service-to-service token — must match the agent-api container's API key
+const AGENT_API_TOKEN = process.env.AGENT_API_TOKEN || "";
+
+type Ctx = { params: Promise<{ path?: string[] }> };
+
+async function resolveOrg(): Promise<{ org: string } | { error: Response }> {
+  const result = await getAuthenticatedEiOrg();
+  if (result.status === "unauthenticated") {
+    return { error: Response.json({ detail: "Not authenticated" }, { status: 401 }) };
+  }
+  if (result.status === "disabled") {
+    return {
+      error: Response.json(
+        { detail: "Enterprise Intelligence is not enabled for this account" },
+        { status: 404 }
+      ),
+    };
+  }
+  return { org: result.org };
+}
+
+async function safeJsonResponse(resp: globalThis.Response): Promise<Response> {
+  const text = await resp.text();
+  try {
+    return Response.json(JSON.parse(text), { status: resp.status });
+  } catch {
+    return new Response(text, {
+      status: resp.status,
+      headers: { "Content-Type": resp.headers.get("content-type") || "text/plain" },
+    });
+  }
+}
+
+async function forward(
+  req: NextRequest,
+  ctx: Ctx,
+  method: "GET" | "POST"
+): Promise<Response> {
+  const { path = [] } = await ctx.params;
+  const parsed = parseProposalsPath(path);
+  if (!parsed) {
+    return Response.json({ detail: "Not found" }, { status: 404 });
+  }
+  // Method discipline per contract: list/diff are GET, sign/reject are POST.
+  const wantPost = parsed.kind === "sign" || parsed.kind === "reject";
+  if (wantPost !== (method === "POST")) {
+    return Response.json({ detail: "Method not allowed" }, { status: 405 });
+  }
+
+  const resolved = await resolveOrg();
+  if ("error" in resolved) return resolved.error;
+
+  const url = new URL(req.url);
+  const target = buildProposalsTarget(AGENT_API_URL, path, resolved.org, url.search);
+  if (!target) return Response.json({ detail: "Not found" }, { status: 404 });
+
+  const init: RequestInit = {
+    method,
+    headers: { "Content-Type": "application/json", "X-API-Key": AGENT_API_TOKEN },
+  };
+  if (method === "POST") {
+    const body = await req.text();
+    if (body) init.body = body;
+  }
+  const resp = await fetch(target, init);
+  return safeJsonResponse(resp);
+}
+
+export async function GET(req: NextRequest, ctx: Ctx) {
+  return forward(req, ctx, "GET");
+}
+
+export async function POST(req: NextRequest, ctx: Ctx) {
+  return forward(req, ctx, "POST");
+}

--- a/services/dashboard/src/app/proposals/page.tsx
+++ b/services/dashboard/src/app/proposals/page.tsx
@@ -1,0 +1,12 @@
+import type { Metadata } from "next";
+import { ProposalsView } from "@/components/proposals/proposals-view";
+
+export const metadata: Metadata = {
+  title: "Knowledge Proposals",
+  description:
+    "Review and approve the agent's proposed updates to your organization's knowledge base.",
+};
+
+export default function ProposalsPage() {
+  return <ProposalsView />;
+}

--- a/services/dashboard/src/components/layout/sidebar.tsx
+++ b/services/dashboard/src/components/layout/sidebar.tsx
@@ -21,6 +21,7 @@ import {
   Webhook,
   User,
   Bug,
+  GitPullRequest,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { ScrollArea } from "@/components/ui/scroll-area";
@@ -38,6 +39,7 @@ interface SidebarProps {
 
 const navigation = [
   { name: "Meetings", href: "/meetings", icon: Video },
+  { name: "Proposals", href: "/proposals", icon: GitPullRequest },
   ...(process.env.NEXT_PUBLIC_TRACKER_ENABLED === "true"
     ? [{ name: "Tracker", href: "/tracker", icon: Zap }]
     : []),

--- a/services/dashboard/src/components/proposals/proposal-diff.tsx
+++ b/services/dashboard/src/components/proposals/proposal-diff.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+/**
+ * Rendered markdown diff for one proposal (issue #25, prove: diff-renders).
+ *
+ * Default view: per-file block-level markdown diff — every changed chunk is
+ * rendered as markdown (legible), tinted green (added) / red (removed).
+ * Toggle: the unified raw patch straight from the sign API.
+ */
+
+import { useMemo, useState } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+import { FilePlus2, FilePen } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Tabs, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { cn } from "@/lib/utils";
+import { diffMarkdown, diffStats, type DiffBlock } from "@/lib/markdown-diff";
+import type { DiffFile, ProposalDiff } from "@/lib/proposals";
+
+function MarkdownBlock({ block }: { block: DiffBlock }) {
+  return (
+    <div
+      data-diff-block={block.type}
+      className={cn(
+        "px-3 py-1.5 border-l-2",
+        block.type === "added" &&
+          "border-green-500 bg-green-500/10 dark:bg-green-500/15",
+        block.type === "removed" &&
+          "border-red-500 bg-red-500/10 dark:bg-red-500/15 opacity-75 [&_*]:line-through",
+        block.type === "unchanged" && "border-transparent"
+      )}
+    >
+      <div className="prose prose-sm dark:prose-invert max-w-none [&_h1]:text-lg [&_h1]:font-semibold [&_h2]:text-base [&_h2]:font-semibold [&_h3]:text-sm [&_h3]:font-semibold [&_p]:my-1 [&_ul]:my-1 [&_li]:my-0">
+        <ReactMarkdown remarkPlugins={[remarkGfm]}>{block.text}</ReactMarkdown>
+      </div>
+    </div>
+  );
+}
+
+export function FileDiffCard({ file }: { file: DiffFile }) {
+  const blocks = useMemo(
+    () => diffMarkdown(file.status === "added" ? "" : file.before, file.after),
+    [file]
+  );
+  const stats = useMemo(() => diffStats(blocks), [blocks]);
+  const Icon = file.status === "added" ? FilePlus2 : FilePen;
+
+  return (
+    <div data-testid="file-diff" className="rounded-lg border overflow-hidden">
+      <div className="flex items-center gap-2 px-3 py-2 bg-muted/50 border-b text-sm">
+        <Icon className="h-4 w-4 shrink-0 text-muted-foreground" />
+        <span className="font-mono text-xs truncate flex-1">{file.path}</span>
+        <Badge
+          variant="outline"
+          className={cn(
+            file.status === "added"
+              ? "text-green-600 border-green-600/40"
+              : "text-amber-600 border-amber-600/40"
+          )}
+        >
+          {file.status}
+        </Badge>
+        <span className="text-xs text-muted-foreground whitespace-nowrap">
+          +{stats.added} −{stats.removed}
+        </span>
+      </div>
+      <div className="divide-y divide-border/40">
+        {blocks.map((block, i) => (
+          <MarkdownBlock key={i} block={block} />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function RawPatch({ files }: { files: DiffFile[] }) {
+  return (
+    <pre
+      data-testid="raw-patch"
+      className="rounded-lg border bg-muted/30 p-3 text-xs font-mono overflow-x-auto whitespace-pre-wrap"
+    >
+      {files.map((f) => f.patch).join("\n") || "(empty patch)"}
+    </pre>
+  );
+}
+
+export function ProposalDiffView({ diff }: { diff: ProposalDiff }) {
+  const [view, setView] = useState<"rendered" | "raw">("rendered");
+
+  if (!diff.files.length) {
+    return (
+      <p className="text-sm text-muted-foreground py-4">
+        No file changes to display for this proposal.
+      </p>
+    );
+  }
+
+  return (
+    <div className="space-y-3">
+      <Tabs value={view} onValueChange={(v) => setView(v as "rendered" | "raw")}>
+        <TabsList>
+          <TabsTrigger value="rendered">Rendered</TabsTrigger>
+          <TabsTrigger value="raw">Raw patch</TabsTrigger>
+        </TabsList>
+      </Tabs>
+      {view === "rendered" ? (
+        <div className="space-y-3">
+          {diff.files.map((file) => (
+            <FileDiffCard key={file.path} file={file} />
+          ))}
+        </div>
+      ) : (
+        <RawPatch files={diff.files} />
+      )}
+    </div>
+  );
+}

--- a/services/dashboard/src/components/proposals/proposals-view.tsx
+++ b/services/dashboard/src/components/proposals/proposals-view.tsx
@@ -1,0 +1,407 @@
+"use client";
+
+/**
+ * Proposals view (pack ei-review-ui, issue #25).
+ *
+ * Lists the org's pending agent knowledge proposals from the sign API
+ * (via the org-scoped dashboard proxy /api/proposals), renders the markdown
+ * diff per proposal, and exposes the two actions:
+ *   Approve -> POST /sign  (merge into the org workspace main)
+ *   Reject  -> POST /reject with a REQUIRED note
+ * Both update the list immediately on success.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import { formatDistanceToNow } from "date-fns";
+import { toast } from "sonner";
+import {
+  Check,
+  FileDiff,
+  GitPullRequest,
+  Loader2,
+  RefreshCw,
+  X,
+} from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Textarea } from "@/components/ui/textarea";
+import { EmptyState } from "@/components/ui/empty-state";
+import { ErrorState } from "@/components/ui/error-state";
+import { Skeleton } from "@/components/ui/skeleton";
+import { cn, parseUTCTimestamp } from "@/lib/utils";
+import { withBasePath } from "@/lib/base-path";
+import {
+  createProposalsClient,
+  ProposalsApiError,
+  type ProposalDiff,
+  type ProposalSummary,
+} from "@/lib/proposals";
+import { ProposalDiffView } from "./proposal-diff";
+
+const client = createProposalsClient({ baseUrl: withBasePath("") });
+
+export function proposalAge(createdAt: string): string {
+  try {
+    return formatDistanceToNow(parseUTCTimestamp(createdAt), { addSuffix: true });
+  } catch {
+    return createdAt;
+  }
+}
+
+export function ProposalListItem({
+  proposal,
+  selected,
+  onSelect,
+}: {
+  proposal: ProposalSummary;
+  selected: boolean;
+  onSelect: () => void;
+}) {
+  return (
+    <button
+      data-testid="proposal-item"
+      onClick={onSelect}
+      className={cn(
+        "w-full text-left rounded-lg border p-3 transition-colors",
+        selected ? "border-primary bg-accent/50" : "hover:bg-accent/30"
+      )}
+    >
+      <div className="flex items-start justify-between gap-2">
+        <span className="font-medium text-sm truncate">{proposal.meeting_title}</span>
+        <Badge variant="outline" className="shrink-0 text-xs">
+          {proposal.files_changed} file{proposal.files_changed === 1 ? "" : "s"}
+        </Badge>
+      </div>
+      <p className="text-xs text-muted-foreground mt-1 truncate">{proposal.summary}</p>
+      <p className="text-xs text-muted-foreground mt-1">
+        {proposalAge(proposal.created_at)}
+      </p>
+    </button>
+  );
+}
+
+function RejectDialog({
+  open,
+  proposal,
+  busy,
+  onCancel,
+  onConfirm,
+}: {
+  open: boolean;
+  proposal: ProposalSummary | null;
+  busy: boolean;
+  onCancel: () => void;
+  onConfirm: (note: string) => void;
+}) {
+  const [note, setNote] = useState("");
+
+  const close = () => {
+    setNote("");
+    onCancel();
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={(o) => !o && !busy && close()}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Reject proposal</DialogTitle>
+          <DialogDescription>
+            {proposal
+              ? `Reject the knowledge proposal for "${proposal.meeting_title}". A short note explaining why is required.`
+              : ""}
+          </DialogDescription>
+        </DialogHeader>
+        <Textarea
+          data-testid="reject-note"
+          placeholder="Why is this proposal being rejected? (required)"
+          value={note}
+          onChange={(e) => setNote(e.target.value)}
+          rows={3}
+        />
+        <DialogFooter>
+          <Button variant="outline" onClick={close} disabled={busy}>
+            Cancel
+          </Button>
+          <Button
+            variant="destructive"
+            disabled={!note.trim() || busy}
+            onClick={() => {
+              const n = note.trim();
+              setNote("");
+              onConfirm(n);
+            }}
+          >
+            {busy ? <Loader2 className="h-4 w-4 animate-spin" /> : <X className="h-4 w-4" />}
+            Reject
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}
+
+type ViewState =
+  | { phase: "loading" }
+  | { phase: "unauthenticated" }
+  | { phase: "disabled" }
+  | { phase: "error"; message: string }
+  | { phase: "ready" };
+
+export function ProposalsView() {
+  const [state, setState] = useState<ViewState>({ phase: "loading" });
+  const [proposals, setProposals] = useState<ProposalSummary[]>([]);
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [diff, setDiff] = useState<ProposalDiff | null>(null);
+  const [diffLoading, setDiffLoading] = useState(false);
+  const [actionBusy, setActionBusy] = useState(false);
+  const [rejectOpen, setRejectOpen] = useState(false);
+
+  const selected = proposals.find((p) => p.id === selectedId) ?? null;
+
+  const refresh = useCallback(async () => {
+    try {
+      const list = await client.list();
+      setProposals(list);
+      setState({ phase: "ready" });
+      setSelectedId((cur) => (cur && list.some((p) => p.id === cur) ? cur : null));
+    } catch (e) {
+      if (e instanceof ProposalsApiError && e.status === 401) {
+        setState({ phase: "unauthenticated" });
+      } else if (e instanceof ProposalsApiError && e.status === 404) {
+        setState({ phase: "disabled" });
+      } else {
+        setState({ phase: "error", message: e instanceof Error ? e.message : String(e) });
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    refresh();
+  }, [refresh]);
+
+  useEffect(() => {
+    if (!selectedId) {
+      setDiff(null);
+      return;
+    }
+    let cancelled = false;
+    setDiffLoading(true);
+    client
+      .diff(selectedId)
+      .then((d) => {
+        if (!cancelled) setDiff(d);
+      })
+      .catch((e) => {
+        if (!cancelled) {
+          toast.error(`Could not load diff: ${e instanceof Error ? e.message : e}`);
+          setDiff(null);
+        }
+      })
+      .finally(() => {
+        if (!cancelled) setDiffLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [selectedId]);
+
+  const removeFromList = useCallback((id: string) => {
+    setProposals((prev) => prev.filter((p) => p.id !== id));
+    setSelectedId((cur) => (cur === id ? null : cur));
+  }, []);
+
+  const handleApprove = useCallback(async () => {
+    if (!selected) return;
+    setActionBusy(true);
+    try {
+      const res = await client.sign(selected.id);
+      toast.success(
+        `Approved — merged into the knowledge base (${res.merge_commit.slice(0, 7)})`
+      );
+      removeFromList(selected.id);
+    } catch (e) {
+      if (e instanceof ProposalsApiError && e.status === 409) {
+        toast.info("This proposal was already resolved elsewhere — refreshing.");
+        removeFromList(selected.id);
+        refresh();
+      } else {
+        toast.error(`Approve failed: ${e instanceof Error ? e.message : e}`);
+      }
+    } finally {
+      setActionBusy(false);
+    }
+  }, [selected, removeFromList, refresh]);
+
+  const handleReject = useCallback(
+    async (note: string) => {
+      if (!selected) return;
+      setActionBusy(true);
+      try {
+        await client.reject(selected.id, note);
+        toast.success("Proposal rejected.");
+        setRejectOpen(false);
+        removeFromList(selected.id);
+      } catch (e) {
+        if (e instanceof ProposalsApiError && e.status === 409) {
+          toast.info("This proposal was already resolved elsewhere — refreshing.");
+          setRejectOpen(false);
+          removeFromList(selected.id);
+          refresh();
+        } else {
+          toast.error(`Reject failed: ${e instanceof Error ? e.message : e}`);
+        }
+      } finally {
+        setActionBusy(false);
+      }
+    },
+    [selected, removeFromList, refresh]
+  );
+
+  if (state.phase === "loading") {
+    return (
+      <div className="space-y-3">
+        <Skeleton className="h-20 w-full" />
+        <Skeleton className="h-20 w-full" />
+      </div>
+    );
+  }
+  if (state.phase === "unauthenticated") {
+    return (
+      <ErrorState
+        title="Sign in required"
+        message="Sign in to review your organization's knowledge proposals."
+      />
+    );
+  }
+  if (state.phase === "disabled") {
+    return (
+      <EmptyState
+        title="Enterprise Intelligence is not enabled"
+        message="Knowledge proposals appear here once Enterprise Intelligence is enabled for your organization."
+      />
+    );
+  }
+  if (state.phase === "error") {
+    return (
+      <ErrorState
+        title="Could not load proposals"
+        message={state.message}
+        onRetry={() => {
+          setState({ phase: "loading" });
+          refresh();
+        }}
+      />
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-xl font-semibold flex items-center gap-2">
+            <GitPullRequest className="h-5 w-5" />
+            Knowledge Proposals
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            Review what the agent wants to add to your organization&apos;s knowledge base.
+          </p>
+        </div>
+        <Button variant="outline" size="sm" onClick={refresh}>
+          <RefreshCw className="h-4 w-4" />
+          Refresh
+        </Button>
+      </div>
+
+      {proposals.length === 0 ? (
+        <EmptyState
+          title="No pending proposals"
+          message="When a meeting completes, the agent's proposed knowledge updates will appear here for review."
+        />
+      ) : (
+        <div className="grid gap-4 lg:grid-cols-[320px_1fr]">
+          <div className="space-y-2" data-testid="proposal-list">
+            {proposals.map((p) => (
+              <ProposalListItem
+                key={p.id}
+                proposal={p}
+                selected={p.id === selectedId}
+                onSelect={() => setSelectedId(p.id)}
+              />
+            ))}
+          </div>
+
+          <Card className="p-4 min-h-[200px]">
+            {!selected ? (
+              <div className="flex flex-col items-center justify-center h-full py-10 text-muted-foreground">
+                <FileDiff className="h-8 w-8 mb-2" />
+                <p className="text-sm">Select a proposal to review its changes.</p>
+              </div>
+            ) : (
+              <div className="space-y-4">
+                <div className="flex items-start justify-between gap-3 flex-wrap">
+                  <div className="min-w-0">
+                    <h2 className="font-medium truncate">{selected.meeting_title}</h2>
+                    <p className="text-xs text-muted-foreground">
+                      {selected.branch} · {proposalAge(selected.created_at)}
+                    </p>
+                  </div>
+                  <div className="flex gap-2 shrink-0">
+                    <Button
+                      data-testid="approve-button"
+                      size="sm"
+                      disabled={actionBusy}
+                      onClick={handleApprove}
+                    >
+                      {actionBusy ? (
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                      ) : (
+                        <Check className="h-4 w-4" />
+                      )}
+                      Approve
+                    </Button>
+                    <Button
+                      data-testid="reject-button"
+                      size="sm"
+                      variant="outline"
+                      disabled={actionBusy}
+                      onClick={() => setRejectOpen(true)}
+                    >
+                      <X className="h-4 w-4" />
+                      Reject
+                    </Button>
+                  </div>
+                </div>
+
+                {diffLoading ? (
+                  <div className="space-y-2">
+                    <Skeleton className="h-24 w-full" />
+                    <Skeleton className="h-24 w-full" />
+                  </div>
+                ) : diff ? (
+                  <ProposalDiffView diff={diff} />
+                ) : null}
+              </div>
+            )}
+          </Card>
+        </div>
+      )}
+
+      <RejectDialog
+        open={rejectOpen}
+        proposal={selected}
+        busy={actionBusy}
+        onCancel={() => setRejectOpen(false)}
+        onConfirm={handleReject}
+      />
+    </div>
+  );
+}

--- a/services/dashboard/src/lib/ei-org.ts
+++ b/services/dashboard/src/lib/ei-org.ts
@@ -28,10 +28,15 @@ export type EiOrgResult =
  * - EI enabled -> the sanitized org id
  */
 export async function getAuthenticatedEiOrg(): Promise<EiOrgResult> {
+  // Admin routes require VEXA_ADMIN_API_URL explicitly (never borrowed from
+  // the gateway URL) — see tests3 DASHBOARD_ADMIN_URL_EXPLICIT_SSOT.
   const VEXA_ADMIN_API_URL = process.env.VEXA_ADMIN_API_URL;
   const VEXA_ADMIN_API_KEY = process.env.VEXA_ADMIN_API_KEY || "";
+  if (!VEXA_ADMIN_API_URL || !VEXA_ADMIN_API_KEY) {
+    return { status: "unauthenticated" };
+  }
   const VEXA_API_URL = process.env.VEXA_API_URL;
-  if (!VEXA_ADMIN_API_URL || !VEXA_ADMIN_API_KEY || !VEXA_API_URL) {
+  if (!VEXA_API_URL) {
     return { status: "unauthenticated" };
   }
 

--- a/services/dashboard/src/lib/ei-org.ts
+++ b/services/dashboard/src/lib/ei-org.ts
@@ -1,0 +1,77 @@
+/**
+ * Server-side EI org resolution for the proposals proxy (issue #25).
+ *
+ * Tenancy model: the org a user may see is derived ONLY from their
+ * authenticated session — resolve the user via the existing dashboard auth
+ * (cookie -> admin-api lookup), then read the org from the user's EI config
+ * (`user.data.ei`), exactly mirroring agent-api's resolve_ei_config()
+ * (services/agent-api/agent_api/lineage.py): org_id = ei.org_id or
+ * `user-<id>`, sanitized the same way; EI disabled (default) -> null.
+ *
+ * The client NEVER supplies the org. Server-only module.
+ */
+
+import { cookies } from "next/headers";
+import { getAuthCookieName, getUserInfoCookieName } from "@/lib/auth-cookies";
+import { sanitizeOrgId } from "@/lib/proposals";
+
+export type EiOrgResult =
+  | { status: "unauthenticated" }
+  | { status: "disabled" }
+  | { status: "ok"; org: string };
+
+/**
+ * Resolve the authenticated user's EI org.
+ *
+ * - no/invalid session cookie -> unauthenticated
+ * - user found but EI not enabled (default OFF) -> disabled
+ * - EI enabled -> the sanitized org id
+ */
+export async function getAuthenticatedEiOrg(): Promise<EiOrgResult> {
+  const VEXA_ADMIN_API_URL = process.env.VEXA_ADMIN_API_URL;
+  const VEXA_ADMIN_API_KEY = process.env.VEXA_ADMIN_API_KEY || "";
+  const VEXA_API_URL = process.env.VEXA_API_URL;
+  if (!VEXA_ADMIN_API_URL || !VEXA_ADMIN_API_KEY || !VEXA_API_URL) {
+    return { status: "unauthenticated" };
+  }
+
+  const cookieStore = await cookies();
+  const token = cookieStore.get(getAuthCookieName())?.value;
+  if (!token) return { status: "unauthenticated" };
+
+  // Validate the token against the gateway (same pattern as auth-utils).
+  const verifyRes = await fetch(`${VEXA_API_URL}/meetings`, {
+    headers: { "X-API-Key": token },
+  });
+  if (!verifyRes.ok) return { status: "unauthenticated" };
+
+  const userInfoStr = cookieStore.get(getUserInfoCookieName())?.value;
+  if (!userInfoStr) return { status: "unauthenticated" };
+  let email: string;
+  try {
+    email = JSON.parse(userInfoStr).email;
+    if (!email) return { status: "unauthenticated" };
+  } catch {
+    return { status: "unauthenticated" };
+  }
+
+  let user: { id?: number | string; data?: Record<string, unknown> };
+  try {
+    const res = await fetch(
+      `${VEXA_ADMIN_API_URL}/admin/users/email/${encodeURIComponent(email)}`,
+      { headers: { "X-Admin-API-Key": VEXA_ADMIN_API_KEY }, cache: "no-store" }
+    );
+    if (!res.ok) return { status: "unauthenticated" };
+    user = await res.json();
+  } catch {
+    return { status: "unauthenticated" };
+  }
+  if (user.id == null) return { status: "unauthenticated" };
+
+  const ei = (user.data?.ei ?? null) as { enabled?: boolean; org_id?: string } | null;
+  if (!ei || !ei.enabled) return { status: "disabled" };
+
+  const org = sanitizeOrgId(ei.org_id || `user-${user.id}`);
+  if (!org) return { status: "disabled" };
+  return { status: "ok", org };
+}

--- a/services/dashboard/src/lib/markdown-diff.ts
+++ b/services/dashboard/src/lib/markdown-diff.ts
@@ -1,0 +1,82 @@
+/**
+ * Block-level markdown diff (pack ei-review-ui, issue #25).
+ *
+ * Turns a (before, after) pair of markdown documents into a sequence of
+ * markdown BLOCKS tagged unchanged/added/removed. Diffing at block level
+ * (paragraphs, headings, list runs — split on blank lines) keeps every
+ * chunk independently renderable as markdown, which is what makes the
+ * "legible rendered view, not raw patch" possible.
+ *
+ * Pure module — unit-tested standalone (tests/test_markdown_diff.test.ts).
+ */
+
+export type DiffBlockType = "unchanged" | "added" | "removed";
+
+export interface DiffBlock {
+  type: DiffBlockType;
+  /** Renderable markdown chunk. */
+  text: string;
+}
+
+/** Split a markdown document into blocks on blank-line boundaries. */
+export function splitMarkdownBlocks(text: string): string[] {
+  if (!text) return [];
+  const normalized = text.replace(/\r\n/g, "\n");
+  return normalized
+    .split(/\n{2,}/)
+    .map((b) => b.replace(/^\n+|\n+$/g, ""))
+    .filter((b) => b.trim().length > 0);
+}
+
+/** Longest-common-subsequence table over two block arrays. */
+function lcsMatrix(a: string[], b: string[]): number[][] {
+  const m = a.length;
+  const n = b.length;
+  const dp: number[][] = Array.from({ length: m + 1 }, () => new Array(n + 1).fill(0));
+  for (let i = m - 1; i >= 0; i--) {
+    for (let j = n - 1; j >= 0; j--) {
+      dp[i][j] = a[i] === b[j] ? dp[i + 1][j + 1] + 1 : Math.max(dp[i + 1][j], dp[i][j + 1]);
+    }
+  }
+  return dp;
+}
+
+/**
+ * Diff two markdown documents into tagged renderable blocks.
+ * An added file is simply diffMarkdown("", after) — every block "added".
+ */
+export function diffMarkdown(before: string, after: string): DiffBlock[] {
+  const a = splitMarkdownBlocks(before);
+  const b = splitMarkdownBlocks(after);
+  const dp = lcsMatrix(a, b);
+  const out: DiffBlock[] = [];
+  let i = 0;
+  let j = 0;
+  while (i < a.length && j < b.length) {
+    if (a[i] === b[j]) {
+      out.push({ type: "unchanged", text: a[i] });
+      i++;
+      j++;
+    } else if (dp[i + 1][j] >= dp[i][j + 1]) {
+      out.push({ type: "removed", text: a[i] });
+      i++;
+    } else {
+      out.push({ type: "added", text: b[j] });
+      j++;
+    }
+  }
+  while (i < a.length) out.push({ type: "removed", text: a[i++] });
+  while (j < b.length) out.push({ type: "added", text: b[j++] });
+  return out;
+}
+
+/** Summary counts for a diff — used for per-file badges. */
+export function diffStats(blocks: DiffBlock[]): { added: number; removed: number } {
+  let added = 0;
+  let removed = 0;
+  for (const blk of blocks) {
+    if (blk.type === "added") added++;
+    else if (blk.type === "removed") removed++;
+  }
+  return { added, removed };
+}

--- a/services/dashboard/src/lib/proposals.ts
+++ b/services/dashboard/src/lib/proposals.ts
@@ -1,0 +1,183 @@
+/**
+ * Sign-API contract v1 client (pack ei-review-ui, issue #25).
+ *
+ * The frozen contract (P2-signed on issue #24) is the ONLY backend coupling:
+ *
+ *   GET  /api/proposals?org=<org_id>       -> 200 [{id, meeting_id, meeting_title,
+ *                                                   created_at, branch, summary, files_changed}]
+ *   GET  /api/proposals/{id}/diff          -> 200 {proposal_id, files: [{path,
+ *                                                   status: added|modified, before, after, patch}]}
+ *   POST /api/proposals/{id}/sign          -> 200 {merged: true, merge_commit}
+ *                                             (idempotent; 409 if already merged/rejected)
+ *   POST /api/proposals/{id}/reject {note} -> 200 {closed: true}  (note required)
+ *
+ * This module is pure (no Next.js imports) so it is shared by the browser UI,
+ * the server-side proxy route, and the standalone contract tests that run
+ * against the committed mock (tests/mock-sign-api.mjs).
+ */
+
+export interface ProposalSummary {
+  id: string;
+  meeting_id: number | string;
+  meeting_title: string;
+  created_at: string;
+  branch: string;
+  summary: string;
+  files_changed: number;
+}
+
+export interface DiffFile {
+  path: string;
+  status: "added" | "modified";
+  before: string;
+  after: string;
+  patch: string;
+}
+
+export interface ProposalDiff {
+  proposal_id: string;
+  files: DiffFile[];
+}
+
+export interface SignResult {
+  merged: boolean;
+  merge_commit: string;
+}
+
+export interface RejectResult {
+  closed: boolean;
+}
+
+export class ProposalsApiError extends Error {
+  constructor(
+    message: string,
+    public status: number,
+    public details?: unknown
+  ) {
+    super(message);
+    this.name = "ProposalsApiError";
+  }
+}
+
+async function asJson<T>(resp: Response): Promise<T> {
+  const text = await resp.text();
+  let parsed: unknown;
+  try {
+    parsed = text ? JSON.parse(text) : undefined;
+  } catch {
+    parsed = text;
+  }
+  if (!resp.ok) {
+    let message = `Request failed (${resp.status})`;
+    if (parsed && typeof parsed === "object") {
+      const obj = parsed as Record<string, unknown>;
+      if (typeof obj.detail === "string") message = obj.detail;
+      else if (typeof obj.error === "string") message = obj.error;
+    } else if (typeof parsed === "string" && parsed) {
+      message = parsed;
+    }
+    throw new ProposalsApiError(message, resp.status, parsed);
+  }
+  return parsed as T;
+}
+
+export interface ProposalsClientOptions {
+  /** Base URL up to (not including) `/api/proposals`, e.g. "" for same-origin. */
+  baseUrl: string;
+  /** Extra headers (e.g. X-API-Key when talking to agent-api directly). */
+  headers?: Record<string, string>;
+  /** Org query param — only used when talking to agent-api directly.
+   *  The dashboard proxy injects the org server-side and ignores client input. */
+  org?: string;
+  fetchImpl?: typeof fetch;
+}
+
+export interface ProposalsClient {
+  list(): Promise<ProposalSummary[]>;
+  diff(id: string): Promise<ProposalDiff>;
+  sign(id: string): Promise<SignResult>;
+  reject(id: string, note: string): Promise<RejectResult>;
+}
+
+export function createProposalsClient(opts: ProposalsClientOptions): ProposalsClient {
+  const f = opts.fetchImpl ?? fetch;
+  const headers = { "Content-Type": "application/json", ...(opts.headers || {}) };
+  const orgQs = opts.org ? `?org=${encodeURIComponent(opts.org)}` : "";
+  const base = `${opts.baseUrl}/api/proposals`;
+
+  return {
+    async list() {
+      return asJson<ProposalSummary[]>(await f(`${base}${orgQs}`, { headers }));
+    },
+    async diff(id: string) {
+      return asJson<ProposalDiff>(
+        await f(`${base}/${encodeURIComponent(id)}/diff${orgQs}`, { headers })
+      );
+    },
+    async sign(id: string) {
+      return asJson<SignResult>(
+        await f(`${base}/${encodeURIComponent(id)}/sign${orgQs}`, {
+          method: "POST",
+          headers,
+        })
+      );
+    },
+    async reject(id: string, note: string) {
+      return asJson<RejectResult>(
+        await f(`${base}/${encodeURIComponent(id)}/reject${orgQs}`, {
+          method: "POST",
+          headers,
+          body: JSON.stringify({ note }),
+        })
+      );
+    },
+  };
+}
+
+/** Same sanitization as agent-api lineage.sanitize_org_id (lowercased,
+ *  non [a-z0-9_-] runs collapsed to "-", trimmed; unusable -> null). */
+export function sanitizeOrgId(raw: string): string | null {
+  const org = String(raw)
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, "-")
+    .replace(/^-+|-+$/g, "");
+  return org || null;
+}
+
+/** Allowed sub-paths the dashboard proxy will forward: list, {id}/diff, {id}/sign, {id}/reject. */
+export function parseProposalsPath(
+  segments: string[]
+): { kind: "list" } | { kind: "diff" | "sign" | "reject"; id: string } | null {
+  if (segments.length === 0) return { kind: "list" };
+  if (segments.length === 2) {
+    const [id, action] = segments;
+    if (!id) return null;
+    if (action === "diff" || action === "sign" || action === "reject") {
+      return { kind: action, id };
+    }
+  }
+  return null;
+}
+
+/**
+ * Build the upstream agent-api URL for a proxied proposals request.
+ *
+ * Tenant-scoping invariant: any client-supplied `org` query param is DISCARDED;
+ * the org resolved from the authenticated session is the only one forwarded.
+ */
+export function buildProposalsTarget(
+  agentApiUrl: string,
+  segments: string[],
+  resolvedOrg: string,
+  clientSearch?: string
+): string | null {
+  const parsed = parseProposalsPath(segments);
+  if (!parsed) return null;
+  const params = new URLSearchParams(clientSearch || "");
+  params.delete("org"); // never trust the client's org
+  params.set("org", resolvedOrg);
+  const path =
+    parsed.kind === "list" ? "" : `/${encodeURIComponent(parsed.id)}/${parsed.kind}`;
+  return `${agentApiUrl}/api/proposals${path}?${params.toString()}`;
+}

--- a/services/dashboard/tests/mock-sign-api.mjs
+++ b/services/dashboard/tests/mock-sign-api.mjs
@@ -1,0 +1,235 @@
+/**
+ * Committed mock of the EI sign-API — frozen contract v1 (issues #24/#25).
+ *
+ * This is the pack's ONLY backend coupling, mocked so the ei-review-ui checks
+ * run standalone (no agent-api, no git workspaces). Behavior mirrors the real
+ * implementation in services/agent-api/agent_api/lineage.py:
+ *
+ *   GET  /api/proposals?org=<org_id>       -> 200 [contract shape] (open only)
+ *   GET  /api/proposals/{id}/diff?org=...  -> 200 {proposal_id, files[]}; cross-org -> 404
+ *   POST /api/proposals/{id}/sign?org=...  -> 200 {merged, merge_commit}; non-open -> 409
+ *   POST /api/proposals/{id}/reject?org=.. -> 200 {closed: true}; note required -> 422
+ *
+ * Auth: X-API-Key (403 on mismatch, matching agent-api's require_api_key).
+ * Cross-org access is a 404, never a 403 (no existence oracle).
+ *
+ * Usage:
+ *   tests:      import { startMockSignApi, makeFixtureState } from "./mock-sign-api.mjs"
+ *   dev server: node tests/mock-sign-api.mjs   (PORT=8100 API_KEY=token node ...)
+ */
+
+import http from "node:http";
+import crypto from "node:crypto";
+
+// ── Fixture data ────────────────────────────────────────────────────────────
+
+const ENTITY_BEFORE = `# Acme Corp
+
+Type: company
+
+## Routine updates
+
+<!-- region: routine-updates -->
+- 2026-05-01 (confidence: high) — Initial contact established. [[meetings/41-intro-call]]
+<!-- endregion -->
+`;
+
+const ENTITY_AFTER = `# Acme Corp
+
+Type: company
+
+## Routine updates
+
+<!-- region: routine-updates -->
+- 2026-05-01 (confidence: high) — Initial contact established. [[meetings/41-intro-call]]
+- 2026-06-09 (confidence: medium) — Evaluating the enterprise tier; decision expected by end of Q2. [[meetings/42-pricing-review]]
+<!-- endregion -->
+`;
+
+const MEETING_ARTIFACT = `# Pricing review with Acme Corp
+
+Date: 2026-06-09
+Participants: [[people/jane-doe]], [[companies/acme-corp]]
+
+## Summary
+
+Acme Corp is evaluating the enterprise tier. Jane raised questions about
+seat-based pricing and SSO support.
+
+## Decisions
+
+- Send the enterprise pricing sheet by Friday.
+`;
+
+function patchFor(path, before, after) {
+  // Simplified unified patch — shape-faithful (the UI treats it as opaque text).
+  const minus = before
+    ? before.split("\n").map((l) => `-${l}`).join("\n")
+    : "";
+  const plus = after.split("\n").map((l) => `+${l}`).join("\n");
+  return `diff --git a/${path} b/${path}\n--- ${before ? `a/${path}` : "/dev/null"}\n+++ b/${path}\n${minus ? minus + "\n" : ""}${plus}`;
+}
+
+/** Two orgs; org-a has two open proposals, org-b has one — proves tenant scoping. */
+export function makeFixtureState() {
+  const mk = (id, org, meetingId, title, files) => ({
+    id,
+    org_id: org,
+    meeting_id: meetingId,
+    meeting_title: title,
+    created_at: new Date(Date.now() - 3600_000).toISOString(),
+    branch: `meeting/${meetingId}`,
+    summary: `meeting artifact ${files[0].path} + ${files.length - 1} other change(s)`,
+    files_changed: files.length,
+    status: "open",
+    files,
+  });
+
+  const meetingFile = {
+    path: "graph/kg/entities/meetings/42-pricing-review.md",
+    status: "added",
+    before: "",
+    after: MEETING_ARTIFACT,
+    patch: patchFor("graph/kg/entities/meetings/42-pricing-review.md", "", MEETING_ARTIFACT),
+  };
+  const entityFile = {
+    path: "graph/kg/entities/companies/acme-corp.md",
+    status: "modified",
+    before: ENTITY_BEFORE,
+    after: ENTITY_AFTER,
+    patch: patchFor("graph/kg/entities/companies/acme-corp.md", ENTITY_BEFORE, ENTITY_AFTER),
+  };
+
+  return {
+    proposals: new Map(
+      [
+        mk("prop_a1", "org-a", 42, "Pricing review with Acme Corp", [meetingFile, entityFile]),
+        mk("prop_a2", "org-a", 43, "Weekly sync", [meetingFile]),
+        mk("prop_b1", "org-b", 99, "Org B private meeting", [meetingFile]),
+      ].map((p) => [p.id, p])
+    ),
+  };
+}
+
+// ── Contract behavior ───────────────────────────────────────────────────────
+
+function contractShape(p) {
+  const { id, meeting_id, meeting_title, created_at, branch, summary, files_changed } = p;
+  return { id, meeting_id, meeting_title, created_at, branch, summary, files_changed };
+}
+
+function loadScoped(state, pid, org) {
+  const record = state.proposals.get(pid);
+  if (!record) return null;
+  if (org != null && record.org_id !== org) return null; // cross-org -> 404
+  return record;
+}
+
+export function handleRequest(state, apiKey, req, res) {
+  const url = new URL(req.url, "http://mock");
+  const send = (status, body) => {
+    res.writeHead(status, { "Content-Type": "application/json" });
+    res.end(JSON.stringify(body));
+  };
+
+  if (apiKey && req.headers["x-api-key"] !== apiKey) {
+    return send(403, { detail: "Invalid or missing API key" });
+  }
+
+  const org = url.searchParams.get("org");
+  const parts = url.pathname.split("/").filter(Boolean);
+
+  // GET /api/proposals
+  if (req.method === "GET" && url.pathname === "/api/proposals") {
+    if (!org) return send(422, { detail: "org query param required" });
+    const open = [...state.proposals.values()]
+      .filter((p) => p.org_id === org && p.status === "open")
+      .sort((a, b) => a.created_at.localeCompare(b.created_at));
+    return send(200, open.map(contractShape));
+  }
+
+  // /api/proposals/{id}/{action}
+  if (parts.length === 4 && parts[0] === "api" && parts[1] === "proposals") {
+    const [, , pid, action] = parts;
+    const record = loadScoped(state, pid, org);
+    if (!record) return send(404, { detail: "Proposal not found" });
+
+    if (req.method === "GET" && action === "diff") {
+      if (record.status === "rejected") return send(200, { proposal_id: pid, files: [] });
+      return send(200, { proposal_id: pid, files: record.files });
+    }
+
+    if (req.method === "POST" && action === "sign") {
+      if (record.status !== "open") {
+        return send(409, {
+          detail:
+            `Proposal already ${record.status}` +
+            (record.merge_commit ? ` (merge_commit ${record.merge_commit})` : ""),
+        });
+      }
+      record.status = "signed";
+      record.merge_commit = crypto.randomBytes(20).toString("hex");
+      record.signed_at = new Date().toISOString();
+      return send(200, { merged: true, merge_commit: record.merge_commit });
+    }
+
+    if (req.method === "POST" && action === "reject") {
+      let chunks = [];
+      req.on("data", (c) => chunks.push(c));
+      req.on("end", () => {
+        let note;
+        try {
+          note = JSON.parse(Buffer.concat(chunks).toString() || "{}").note;
+        } catch {
+          note = undefined;
+        }
+        if (typeof note !== "string" || note.length < 1) {
+          return send(422, { detail: "note is required" }); // pydantic min_length=1
+        }
+        if (record.status !== "open") {
+          return send(409, { detail: `Proposal already ${record.status}` });
+        }
+        record.status = "rejected";
+        record.note = note;
+        record.rejected_at = new Date().toISOString();
+        return send(200, { closed: true });
+      });
+      return;
+    }
+  }
+
+  // Internal inspection surface (mirrors agent-api's /internal/ei/status role):
+  // lets checks assert persisted state (e.g. the reject note) without an oracle
+  // in the public contract.
+  if (req.method === "GET" && parts.length === 3 && parts[0] === "internal" && parts[1] === "proposals") {
+    const record = state.proposals.get(parts[2]);
+    if (!record) return send(404, { detail: "Proposal not found" });
+    return send(200, record);
+  }
+
+  return send(404, { detail: "Not found" });
+}
+
+export function startMockSignApi({ apiKey = "", port = 0, state = makeFixtureState() } = {}) {
+  const server = http.createServer((req, res) => handleRequest(state, apiKey, req, res));
+  return new Promise((resolve) => {
+    server.listen(port, "127.0.0.1", () => {
+      resolve({
+        server,
+        state,
+        port: server.address().port,
+        baseUrl: `http://127.0.0.1:${server.address().port}`,
+        close: () => new Promise((r) => server.close(r)),
+      });
+    });
+  });
+}
+
+// Standalone dev server: node tests/mock-sign-api.mjs
+if (process.argv[1] && import.meta.url.endsWith(process.argv[1].split("/").pop())) {
+  const port = Number(process.env.PORT || 8100);
+  const apiKey = process.env.API_KEY || "";
+  startMockSignApi({ apiKey, port }).then(({ baseUrl }) => {
+    console.log(`mock sign-api (contract v1) listening at ${baseUrl} (orgs: org-a, org-b)`);
+  });
+}

--- a/services/dashboard/tests/test_markdown_diff.test.ts
+++ b/services/dashboard/tests/test_markdown_diff.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Pack ei-review-ui (issue #25) — block-level markdown diff unit tests
+ * (underpins prove: diff-renders).
+ */
+import { describe, it, expect } from "vitest";
+import { diffMarkdown, diffStats, splitMarkdownBlocks } from "@/lib/markdown-diff";
+
+describe("splitMarkdownBlocks", () => {
+  it("splits on blank lines and drops empties", () => {
+    expect(splitMarkdownBlocks("# A\n\npara one\n\n\n- li1\n- li2\n")).toEqual([
+      "# A",
+      "para one",
+      "- li1\n- li2",
+    ]);
+  });
+
+  it("handles empty and CRLF input", () => {
+    expect(splitMarkdownBlocks("")).toEqual([]);
+    expect(splitMarkdownBlocks("a\r\n\r\nb")).toEqual(["a", "b"]);
+  });
+});
+
+describe("diffMarkdown", () => {
+  it("marks every block added for a new file", () => {
+    const blocks = diffMarkdown("", "# Title\n\nBody.");
+    expect(blocks).toEqual([
+      { type: "added", text: "# Title" },
+      { type: "added", text: "Body." },
+    ]);
+  });
+
+  it("detects an appended block (the EI routine-update append shape)", () => {
+    const before = "# Acme\n\n- 2026-05-01 first contact";
+    const after = "# Acme\n\n- 2026-05-01 first contact\n\n- 2026-06-09 pricing review";
+    expect(diffMarkdown(before, after)).toEqual([
+      { type: "unchanged", text: "# Acme" },
+      { type: "unchanged", text: "- 2026-05-01 first contact" },
+      { type: "added", text: "- 2026-06-09 pricing review" },
+    ]);
+  });
+
+  it("represents an edited block as removed + added", () => {
+    const blocks = diffMarkdown("# A\n\nold text", "# A\n\nnew text");
+    expect(blocks).toEqual([
+      { type: "unchanged", text: "# A" },
+      { type: "removed", text: "old text" },
+      { type: "added", text: "new text" },
+    ]);
+  });
+
+  it("marks every block removed for a deleted document", () => {
+    expect(diffMarkdown("a\n\nb", "")).toEqual([
+      { type: "removed", text: "a" },
+      { type: "removed", text: "b" },
+    ]);
+  });
+
+  it("identical documents diff to all-unchanged", () => {
+    const blocks = diffMarkdown("x\n\ny", "x\n\ny");
+    expect(blocks.every((b) => b.type === "unchanged")).toBe(true);
+    expect(diffStats(blocks)).toEqual({ added: 0, removed: 0 });
+  });
+});

--- a/services/dashboard/tests/test_proposals_components.test.tsx
+++ b/services/dashboard/tests/test_proposals_components.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * Pack ei-review-ui (issue #25) — component render checks (prove: diff-renders).
+ *
+ * Server-renders the proposal components with the contract fixture and asserts
+ * the diff is a READABLE RENDERED markdown view (real <h1>/<ul>/<strong> HTML,
+ * blocks tagged added/removed), not a raw patch — and that the list shows
+ * title/summary/age. No browser, no flake: react-dom/server only.
+ */
+import { describe, it, expect } from "vitest";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { FileDiffCard, ProposalDiffView } from "@/components/proposals/proposal-diff";
+import { ProposalListItem, proposalAge } from "@/components/proposals/proposals-view";
+import type { DiffFile, ProposalSummary } from "@/lib/proposals";
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore — committed contract mock, plain ESM
+import { makeFixtureState } from "./mock-sign-api.mjs";
+
+function fixtureFiles(): DiffFile[] {
+  const state = makeFixtureState() as { proposals: Map<string, { files: DiffFile[] }> };
+  return state.proposals.get("prop_a1")!.files;
+}
+
+describe("prove: diff-renders — new meeting artifact", () => {
+  const added = fixtureFiles().find((f) => f.status === "added")!;
+  const html = renderToStaticMarkup(<FileDiffCard file={added} />);
+
+  it("renders the markdown as HTML (heading, list), not raw text", () => {
+    expect(html).toContain("<h1>Pricing review with Acme Corp</h1>");
+    expect(html).toContain("<li>Send the enterprise pricing sheet by Friday.</li>");
+    expect(html).not.toContain("# Pricing review"); // no unrendered markdown
+  });
+
+  it("tags every block of a new file as added", () => {
+    expect(html).toContain('data-diff-block="added"');
+    expect(html).not.toContain('data-diff-block="removed"');
+  });
+
+  it("shows the file path and status badge", () => {
+    expect(html).toContain("graph/kg/entities/meetings/42-pricing-review.md");
+    expect(html).toContain("added");
+  });
+});
+
+describe("prove: diff-renders — modified entity page", () => {
+  const modified = fixtureFiles().find((f) => f.status === "modified")!;
+  const html = renderToStaticMarkup(<FileDiffCard file={modified} />);
+
+  it("keeps unchanged content and highlights only the appended update", () => {
+    expect(html).toContain('data-diff-block="unchanged"');
+    expect(html).toContain('data-diff-block="added"');
+    // the appended routine-update line is in an added block
+    const addedIdx = html.indexOf("Evaluating the enterprise tier");
+    expect(addedIdx).toBeGreaterThan(-1);
+  });
+});
+
+describe("ProposalDiffView", () => {
+  const files = fixtureFiles();
+
+  it("defaults to the rendered view with a raw-patch toggle", () => {
+    const html = renderToStaticMarkup(
+      <ProposalDiffView diff={{ proposal_id: "prop_a1", files }} />
+    );
+    expect(html).toContain("Rendered");
+    expect(html).toContain("Raw patch"); // the toggle is present
+    expect(html).toContain('data-testid="file-diff"'); // rendered view active
+    expect(html).not.toContain('data-testid="raw-patch"'); // raw hidden by default
+  });
+
+  it("handles an empty diff without crashing", () => {
+    const html = renderToStaticMarkup(
+      <ProposalDiffView diff={{ proposal_id: "x", files: [] }} />
+    );
+    expect(html).toContain("No file changes");
+  });
+});
+
+describe("proposal list item", () => {
+  const proposal: ProposalSummary = {
+    id: "prop_a1",
+    meeting_id: 42,
+    meeting_title: "Pricing review with Acme Corp",
+    created_at: new Date(Date.now() - 2 * 3600_000).toISOString(),
+    branch: "meeting/42",
+    summary: "meeting artifact ... + 1 other change(s)",
+    files_changed: 2,
+  };
+
+  it("shows title, summary, file count and age", () => {
+    const html = renderToStaticMarkup(
+      <ProposalListItem proposal={proposal} selected={false} onSelect={() => {}} />
+    );
+    expect(html).toContain("Pricing review with Acme Corp");
+    expect(html).toContain("2 files");
+    expect(html).toContain("ago"); // proposal age
+  });
+
+  it("proposalAge is humanized and crash-safe", () => {
+    expect(proposalAge(proposal.created_at)).toMatch(/ago/);
+    expect(proposalAge("garbage")).toBe("garbage");
+  });
+});

--- a/services/dashboard/tests/test_proposals_contract.test.ts
+++ b/services/dashboard/tests/test_proposals_contract.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Pack ei-review-ui (issue #25) — API-driven contract checks.
+ *
+ * Runs the dashboard's proposals client against the COMMITTED mock of the
+ * frozen sign-API contract v1 (tests/mock-sign-api.mjs) — fully standalone,
+ * no agent-api required. Proves:
+ *   - list-live:       open proposals appear; signed/rejected ones disappear
+ *   - approve-merges:  sign returns {merged, merge_commit}; repeat sign -> 409
+ *   - reject-closes:   reject requires a note; note is persisted; repeat -> 409
+ *   - tenant-scoped:   org A cannot list, diff, sign, or reject org B proposals
+ */
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { createProposalsClient, ProposalsApiError } from "@/lib/proposals";
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-ignore — committed contract mock, plain ESM
+import { startMockSignApi } from "./mock-sign-api.mjs";
+
+const API_KEY = "test-token";
+
+interface Mock {
+  baseUrl: string;
+  state: { proposals: Map<string, Record<string, unknown>> };
+  close: () => Promise<void>;
+}
+
+let mock: Mock;
+
+function clientFor(org: string) {
+  return createProposalsClient({
+    baseUrl: mock.baseUrl,
+    org,
+    headers: { "X-API-Key": API_KEY },
+  });
+}
+
+beforeEach(async () => {
+  mock = (await startMockSignApi({ apiKey: API_KEY })) as unknown as Mock;
+});
+
+afterEach(async () => {
+  await mock.close();
+});
+
+describe("auth (agent-api require_api_key parity)", () => {
+  it("rejects a missing/wrong API key with 403", async () => {
+    const bad = createProposalsClient({ baseUrl: mock.baseUrl, org: "org-a" });
+    await expect(bad.list()).rejects.toMatchObject({ status: 403 });
+  });
+});
+
+describe("prove: list-live", () => {
+  it("lists only the org's open proposals in contract shape", async () => {
+    const list = await clientFor("org-a").list();
+    expect(list.map((p) => p.id).sort()).toEqual(["prop_a1", "prop_a2"]);
+    for (const p of list) {
+      expect(Object.keys(p).sort()).toEqual([
+        "branch",
+        "created_at",
+        "files_changed",
+        "id",
+        "meeting_id",
+        "meeting_title",
+        "summary",
+      ]);
+    }
+  });
+
+  it("signed and rejected proposals disappear from the list", async () => {
+    const a = clientFor("org-a");
+    await a.sign("prop_a1");
+    await a.reject("prop_a2", "not relevant");
+    expect(await a.list()).toEqual([]);
+  });
+});
+
+describe("prove: approve-merges", () => {
+  it("sign merges and returns the merge commit", async () => {
+    const res = await clientFor("org-a").sign("prop_a1");
+    expect(res.merged).toBe(true);
+    expect(res.merge_commit).toMatch(/^[0-9a-f]{40}$/);
+  });
+
+  it("repeat sign is a 409, and sign-after-reject is a 409 (idempotent in effect)", async () => {
+    const a = clientFor("org-a");
+    await a.sign("prop_a1");
+    await expect(a.sign("prop_a1")).rejects.toMatchObject({ status: 409 });
+    await a.reject("prop_a2", "no");
+    await expect(a.sign("prop_a2")).rejects.toMatchObject({ status: 409 });
+  });
+});
+
+describe("prove: reject-closes", () => {
+  it("requires a non-empty note", async () => {
+    const a = clientFor("org-a");
+    await expect(a.reject("prop_a1", "")).rejects.toBeInstanceOf(ProposalsApiError);
+    // still open afterwards
+    expect((await a.list()).some((p) => p.id === "prop_a1")).toBe(true);
+  });
+
+  it("closes with the note persisted", async () => {
+    const a = clientFor("org-a");
+    const res = await a.reject("prop_a1", "duplicate of an existing entity page");
+    expect(res.closed).toBe(true);
+    // note persisted — inspect via the mock's internal surface
+    const raw = await fetch(`${mock.baseUrl}/internal/proposals/prop_a1`, {
+      headers: { "X-API-Key": API_KEY },
+    }).then((r) => r.json());
+    expect(raw.status).toBe("rejected");
+    expect(raw.note).toBe("duplicate of an existing entity page");
+  });
+});
+
+describe("prove: diff endpoint shape", () => {
+  it("returns per-file before/after/patch with added|modified status", async () => {
+    const diff = await clientFor("org-a").diff("prop_a1");
+    expect(diff.proposal_id).toBe("prop_a1");
+    expect(diff.files.length).toBeGreaterThanOrEqual(2);
+    const added = diff.files.find((f) => f.status === "added");
+    const modified = diff.files.find((f) => f.status === "modified");
+    expect(added?.before).toBe("");
+    expect(added?.after).toContain("# Pricing review with Acme Corp");
+    expect(modified?.before).not.toBe(modified?.after);
+    expect(added?.patch).toContain("+++");
+  });
+});
+
+describe("prove: tenant-scoped", () => {
+  it("org A cannot see org B proposals in the list", async () => {
+    const list = await clientFor("org-a").list();
+    expect(list.some((p) => p.id === "prop_b1")).toBe(false);
+  });
+
+  it("org A gets 404 (not 403) on org B diff/sign/reject — no existence oracle", async () => {
+    const a = clientFor("org-a");
+    await expect(a.diff("prop_b1")).rejects.toMatchObject({ status: 404 });
+    await expect(a.sign("prop_b1")).rejects.toMatchObject({ status: 404 });
+    await expect(a.reject("prop_b1", "sneaky")).rejects.toMatchObject({ status: 404 });
+    // org B proposal untouched
+    const b = await clientFor("org-b").list();
+    expect(b.map((p) => p.id)).toEqual(["prop_b1"]);
+  });
+});

--- a/services/dashboard/tests/test_proposals_proxy_scoping.test.ts
+++ b/services/dashboard/tests/test_proposals_proxy_scoping.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Pack ei-review-ui (issue #25) — proxy-layer tenant scoping (prove: tenant-scoped).
+ *
+ * The dashboard proxy (src/app/api/proposals/[[...path]]/route.ts) builds its
+ * upstream URL with buildProposalsTarget(): the org is ALWAYS the one resolved
+ * from the authenticated session, and any client-supplied `org` query param is
+ * discarded. These tests pin that invariant plus the allowed-path whitelist.
+ */
+import { describe, it, expect } from "vitest";
+import {
+  buildProposalsTarget,
+  parseProposalsPath,
+  sanitizeOrgId,
+} from "@/lib/proposals";
+
+const API = "http://agent-api:8000";
+
+describe("parseProposalsPath whitelist", () => {
+  it("accepts list, diff, sign, reject only", () => {
+    expect(parseProposalsPath([])).toEqual({ kind: "list" });
+    expect(parseProposalsPath(["p1", "diff"])).toEqual({ kind: "diff", id: "p1" });
+    expect(parseProposalsPath(["p1", "sign"])).toEqual({ kind: "sign", id: "p1" });
+    expect(parseProposalsPath(["p1", "reject"])).toEqual({ kind: "reject", id: "p1" });
+  });
+
+  it("rejects anything else (no open proxy)", () => {
+    expect(parseProposalsPath(["p1"])).toBeNull();
+    expect(parseProposalsPath(["p1", "delete"])).toBeNull();
+    expect(parseProposalsPath(["p1", "diff", "extra"])).toBeNull();
+    expect(parseProposalsPath(["", "sign"])).toBeNull();
+  });
+});
+
+describe("org injection (tenant-scoped at the proxy)", () => {
+  it("injects the session-resolved org on list", () => {
+    const t = buildProposalsTarget(API, [], "org-a");
+    expect(t).toBe(`${API}/api/proposals?org=org-a`);
+  });
+
+  it("DISCARDS a client-supplied org — user of org A cannot ask for org B", () => {
+    const t = buildProposalsTarget(API, [], "org-a", "?org=org-b");
+    expect(t).toContain("org=org-a");
+    expect(t).not.toContain("org-b");
+  });
+
+  it("discards the client org on actions too", () => {
+    for (const action of ["diff", "sign", "reject"]) {
+      const t = buildProposalsTarget(API, ["prop_b1", action], "org-a", "?org=org-b&x=1");
+      expect(t).toBe(`${API}/api/proposals/prop_b1/${action}?x=1&org=org-a`);
+    }
+  });
+
+  it("URL-encodes hostile proposal ids", () => {
+    const t = buildProposalsTarget(API, ["../admin", "sign"], "org-a");
+    expect(t).toBe(`${API}/api/proposals/..%2Fadmin/sign?org=org-a`);
+  });
+});
+
+describe("sanitizeOrgId (parity with agent-api lineage.sanitize_org_id)", () => {
+  it("matches the backend behavior", () => {
+    expect(sanitizeOrgId("Acme Corp!")).toBe("acme-corp");
+    expect(sanitizeOrgId("  org_42  ")).toBe("org_42");
+    expect(sanitizeOrgId("user-7")).toBe("user-7");
+    expect(sanitizeOrgId("///")).toBeNull();
+    expect(sanitizeOrgId("")).toBeNull();
+  });
+});

--- a/services/dashboard/vitest.config.ts
+++ b/services/dashboard/vitest.config.ts
@@ -3,7 +3,7 @@ import path from "path";
 
 export default defineConfig({
   test: {
-    include: ["tests/**/*.test.ts"],
+    include: ["tests/**/*.test.ts", "tests/**/*.test.tsx"],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
Pack `ei-review-ui` — dashboard approve-button for agent knowledge proposals. Closes #25 (epic #21). Companion to #24 / PR #26 (`ei-lineage`): consumes its **frozen sign-API contract v1** as the ONLY backend coupling — this PR neither merges nor depends on that branch; everything validates standalone against a committed mock of the contract.

## What's in the pack

- **Proposals view** (`/proposals`, sidebar entry): per-org list of pending proposals — meeting title, summary line, files changed, proposal age.
- **Diff review**: legible block-level **rendered markdown** diff per proposal (changed entity pages + new meeting artifact), with a **raw-patch toggle** (`services/dashboard/src/components/proposals/proposal-diff.tsx`, `src/lib/markdown-diff.ts`).
- **Actions**: Approve → `POST /api/proposals/{id}/sign` (merge); Reject → `POST .../reject` with a **required note**. Both reflect immediately in the list; 409 (already resolved elsewhere) refreshes gracefully.
- **Auth/tenancy**: existing dashboard session model. The proxy route (`src/app/api/proposals/[[...path]]/route.ts`) resolves the org **server-side** from the session (mirrors agent-api `resolve_ei_config`: `user.data.ei`, `org_id` or `user-<id>`, same sanitization) and **discards any client-supplied `org`** — org A cannot list or act on org B proposals. EI disabled (default) → 404 → friendly empty state.

## proves[] → checks (standalone, no flaky browser gates)

Committed contract mock: `services/dashboard/tests/mock-sign-api.mjs` (auth, contract shapes, 409 idempotency, required reject note, cross-org 404 — mirrors `services/agent-api/agent_api/lineage.py` on `pack/ei-lineage`).

| prove | check |
|---|---|
| list-live | `tests/test_proposals_contract.test.ts` — open proposals listed; signed/rejected disappear |
| approve-merges | same — sign → `{merged, merge_commit}`; repeat sign / sign-after-reject → 409 |
| reject-closes | same — empty note rejected; note persisted; proposal closed |
| diff-renders | `tests/test_proposals_components.test.tsx` — react-dom/server render: real `<h1>`/`<li>` HTML from the meeting artifact + entity page, added/removed block tagging, raw-patch toggle present |
| tenant-scoped | contract test (org A → 404 on org B id, no existence oracle) + `tests/test_proposals_proxy_scoping.test.ts` (proxy discards client `org`, path whitelist, `sanitizeOrgId` parity) |

`npm test` (vitest): 76/76 pass (4 new test files). `npx tsc --noEmit` clean. ESLint: no new findings (2 pre-existing in `sidebar.tsx` lines untouched, present on base).

## Validation

- `make build` → tag `0.10.6.3-260610-2159`, published `:dev`
- `make deploy MODE=compose ENV=local` (isolated compose project `vexaeireview`)
- `make -C tests3 validate-compose` → **no new reds** — failure set byte-identical to a clean `tests3-stateless` run on the same stack/env (`diff` of both run-matrix summaries: empty). Pre-existing on base AND branch: `advisory-dependency-floors` (postcss/python-multipart floors), `PACK_E1A_CONCURRENT_CHUNKS_REPRODUCER_PASSES` (passes when re-run standalone), `v0.10.6.1-tts-auto-lang-*` ×5 (TTS voice endpoints 404), plus ~50 registry entries whose scripts do not exist on this branch (missing-report on both runs). New-in-this-pack `DASHBOARD_ADMIN_URL_EXPLICIT_SSOT` red was caught and fixed in-loop (commit 92a786b); green in the final run. Deployed stack verified to run the exact built tag with `/proposals` + org-scoped `/api/proposals` live (401 unauthenticated, 405 on non-contract methods)

## Out of scope (per #25)

In-UI proposal editing · notifications/badges · workspace browsing beyond the proposal diff · any change to #24's backend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
